### PR TITLE
derive: re-export im

### DIFF
--- a/uniplate-derive/src/lib.rs
+++ b/uniplate-derive/src/lib.rs
@@ -156,7 +156,7 @@ fn _derive_children(state: &mut ParserState, fields: &[ast::Field]) -> TokenStre
         0 => quote! {let children = ::uniplate::Tree::Zero;},
         _ => {
             let subtrees = subtrees.iter();
-            quote! {let children = ::uniplate::Tree::Many(::im::vector![#(#subtrees),*]);}
+            quote! {let children = ::uniplate::Tree::Many(::uniplate::_dependencies::im::vector![#(#subtrees),*]);}
         }
     }
 }

--- a/uniplate/src/lib.rs
+++ b/uniplate/src/lib.rs
@@ -226,6 +226,11 @@ pub use uniplate_derive::*;
 
 extern crate self as uniplate;
 
+#[doc(hidden)]
+pub mod _dependencies {
+    pub use im;
+}
+
 /// Generates a Biplate and Uniplate instance for an unplateable type.
 #[macro_export]
 macro_rules! derive_unplateable {


### PR DESCRIPTION
Re-export im through uniplate. This fixes dependency issues when the crate in which derive is used does not have im in the Cargo.toml.