### PR TITLE
Clean up warnings in cargo test

### DIFF
--- a/uniplate/examples/stmt.rs
+++ b/uniplate/examples/stmt.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use uniplate::derive::Uniplate;
-use uniplate::{Biplate, Uniplate};
+use uniplate::Biplate;
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[uniplate()]

--- a/uniplate/src/test_common/paper.rs
+++ b/uniplate/src/test_common/paper.rs
@@ -1,6 +1,6 @@
 use crate::derive::Uniplate;
-use crate::{Biplate, Uniplate};
-use prop::sample::SizeRange;
+#[cfg(test)]
+use crate::Uniplate;
 use proptest::prelude::*;
 
 // Examples found in the Uniplate paper.

--- a/uniplate/tests/derive-pass/biplate-stmt.rs
+++ b/uniplate/tests/derive-pass/biplate-stmt.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use uniplate::{Biplate, Uniplate,derive::Uniplate};
+use uniplate::{derive::Uniplate, Biplate};
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[biplate(to=Expr)]


### PR DESCRIPTION
these gave unused imports warnings previously. `cargo test` runs without any warnings now.