### PR TITLE
Keywords and categories

### DIFF
--- a/uniplate/Cargo.toml
+++ b/uniplate/Cargo.toml
@@ -10,8 +10,8 @@ description = "Simple, boilerplate-free operations on tree-shaped data types"
 readme = "../README.md" # use base repository's readme.
 repository = "https://github.com/conjure-cp/uniplate"
 license = "MPL-2.0"
-keywords = ["macro"]
-categories = ["rust-patterns", "data-structures", "algorithms", "parsing"]
+keywords = ["generics", "traversals", "macro"]
+categories = ["rust-patterns", "data-structures", "algorithms"]
 
 [lib]
 


### PR DESCRIPTION
Not final, we can fiddle with these more of course. I just thought we should have generics and traversals (both seem popular as keywords on crates.io) and I removed parsing since I don't think this library should be seen as a parsing library.

Also I don't know why they have both keywords and categories, I guess the latter is curated and that's the only difference...