### PR TITLE
feat: add Biplate::with_children_bi

### DIFF
--- a/uniplate/src/traits.rs
+++ b/uniplate/src/traits.rs
@@ -18,6 +18,27 @@ where
     /// If from == to then this function should return the root as the single child.
     fn biplate(&self) -> (Tree<To>, Box<dyn Fn(Tree<To>) -> Self>);
 
+    /// Reconstructs the node with the given children.
+    ///
+    /// # Panics
+    ///
+    /// If there are a different number of children given as there were originally returned by
+    /// children().
+    fn with_children_bi(&self, children: im::Vector<To>) -> Self {
+        // 1. Turn old tree into list.
+        // 2. Check lists are same size.
+        // 3. Use the reconstruction function given by old_children.list() to
+        //   create a tree with the same structure but the new lists' elements .
+
+        let (old_children, ctx) = self.biplate();
+        let (old_children_lst, rebuild) = old_children.list();
+        if old_children_lst.len() != children.len() {
+            panic!("with_children() given an unexpected amount of children");
+        } else {
+            ctx(rebuild(children))
+        }
+    }
+
     /// Like descend but with more general types.
     ///
     /// If from == to then this function does not descend. Therefore, when writing definitions it

--- a/uniplate/tests/derive-pass/biplate-stmt.rs
+++ b/uniplate/tests/derive-pass/biplate-stmt.rs
@@ -40,4 +40,14 @@ pub fn main() {
     assert_eq!(strings_in_stmt_1.len(), 2);
     assert!(strings_in_stmt_1.contains(&"x".into()));
     assert!(strings_in_stmt_1.contains(&"y".into()));
+
+    // same type property
+    let children = <Stmt as Biplate<Stmt>>::children_bi(&stmt_1);
+    assert_eq!(children.len(),1);
+    assert_eq!(children[0],stmt_1);
+
+    // test with_children_bi
+    let children = <Stmt as Biplate<String>>::children_bi(&stmt_1);
+    let reconstructed = <Stmt as Biplate<String>>::with_children_bi(&stmt_1,children);
+    assert_eq!(reconstructed,stmt_1);
 }


### PR DESCRIPTION
Add Biplate::with_children_bi method. This is identical to
Uniplate::with_children, but for a Biplate.

Fixes: #25
