### PR TITLE
feat: add `Uniplate::holes` and `Uniplate::contexts`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "uniplate"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "im",
  "proptest",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "uniplate-derive"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "itertools",
  "lazy_static",


### PR DESCRIPTION
Port `holes` and `context` functions from the original Haskell library.
