### PR TITLE
refactor!: remove `proptest` as a dependency

### DIFF
--- a/uniplate-derive/src/state.rs
+++ b/uniplate-derive/src/state.rs
@@ -68,7 +68,7 @@ impl ParserState {
     }
 
     /// Checks if a type can be walked into or not
-
+    ///
     /// This acts similarly to ast::InstanceMeta::walk_into_type but also considers the
     /// current to and from type as walkable.
     pub fn walk_into_type(&self, typ: &ast::Type) -> bool {

--- a/uniplate/Cargo.toml
+++ b/uniplate/Cargo.toml
@@ -16,13 +16,13 @@ categories = ["rust-patterns", "data-structures", "algorithms"]
 [lib]
 
 [dependencies]
-proptest = "1.6.0"
-proptest-derive = "0.5.1"
 thiserror = "2.0.9"
 uniplate-derive = { version = "0.1.5", path = "../uniplate-derive" }
 
 [dev-dependencies]
 trybuild = "1.0.101"
+proptest = "1.6.0"
+proptest-derive = "0.5.1"
 
 #[lints]
 #workspace = true

--- a/uniplate/src/tree.rs
+++ b/uniplate/src/tree.rs
@@ -2,8 +2,6 @@
 
 use std::{collections::VecDeque, sync::Arc};
 
-use proptest::prelude::*;
-
 use self::Tree::*;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -84,27 +82,28 @@ impl<T: Sized + Clone + Eq + 'static> Tree<T> {
     }
 }
 
-// FIXME: move into tests module so that proptest is not a public dependency
-#[allow(dead_code)]
-// Used by proptest for generating test instances of Tree<i32>.
-fn proptest_integer_trees() -> impl Strategy<Value = Tree<i32>> {
-    // https://proptest-rs.github.io/proptest/proptest/tutorial/enums.html
-    // https://proptest-rs.github.io/proptest/proptest/tutorial/recursive.html
-    let leaf = prop_oneof![Just(Tree::Zero), any::<i32>().prop_map(Tree::One),];
-
-    leaf.prop_recursive(
-        10,  // levels deep
-        512, // Shoot for maximum size of 512 nodes
-        20,  // We put up to 20 items per collection
-        |inner| proptest::collection::vec_deque(inner.clone(), 0..20).prop_map(Tree::Many),
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use std::iter::zip;
 
+    use proptest::prelude::*;
+
     use super::*;
+
+    #[allow(dead_code)]
+    // Used by proptest for generating test instances of Tree<i32>.
+    fn proptest_integer_trees() -> impl Strategy<Value = Tree<i32>> {
+        // https://proptest-rs.github.io/proptest/proptest/tutorial/enums.html
+        // https://proptest-rs.github.io/proptest/proptest/tutorial/recursive.html
+        let leaf = prop_oneof![Just(Tree::Zero), any::<i32>().prop_map(Tree::One),];
+
+        leaf.prop_recursive(
+            10,  // levels deep
+            512, // Shoot for maximum size of 512 nodes
+            20,  // We put up to 20 items per collection
+            |inner| proptest::collection::vec_deque(inner.clone(), 0..20).prop_map(Tree::Many),
+        )
+    }
 
     proptest! {
         #[test]


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #43

## Chain of upstream PRs as of 2025-01-12

* PR #43:
  `main` ← `nik/use-std-vector`

  * **PR #44 (THIS ONE)**:
    `nik/use-std-vector` ← `nik/remove-proptest-dependency`

<!-- end git-machete generated -->

---

Refactor testing code to remove `proptest` as a dependency. Make it a
dev-dependency so that it is in test code only.
