### PR TITLE
fix: broken Biplate for basic types (i32, etc), transform_bi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,7 +784,7 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "uniplate"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "criterion",
  "proptest",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "uniplate-derive"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "itertools 0.14.0",
  "lazy_static",

--- a/uniplate/examples/biplate-stmt.rs
+++ b/uniplate/examples/biplate-stmt.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
-use uniplate::{derive::Uniplate, Biplate};
 use std::collections::VecDeque;
 use std::sync::Arc;
+use uniplate::{derive::Uniplate, Biplate};
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[biplate(to=Expr)]
@@ -37,7 +37,10 @@ pub fn main() {
     use Expr::*;
     use Stmt::*;
 
-    let stmt_1 = Assign("x".into(), Some(Div(Box::new(Val(2)), Box::new(Var("y".into())))));
+    let stmt_1 = Assign(
+        "x".into(),
+        Some(Div(Box::new(Val(2)), Box::new(Var("y".into())))),
+    );
 
     let strings_in_stmt_1: VecDeque<String> = stmt_1.universe_bi();
 
@@ -48,31 +51,33 @@ pub fn main() {
 
     // same type property
     let children: VecDeque<Stmt> = stmt_1.children_bi();
-    assert_eq!(children.len(),1);
-    assert_eq!(children[0],stmt_1);
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0], stmt_1);
 
     // test with_children_bi
     let children: VecDeque<String> = stmt_1.children_bi();
     let reconstructed: Stmt = stmt_1.with_children_bi(children);
-    assert_eq!(reconstructed,stmt_1);
+    assert_eq!(reconstructed, stmt_1);
 
     // test descend_bi on ints
-    let stmt_1_ints= VecDeque::from([2]);
+    let stmt_1_ints = VecDeque::from([2]);
 
-    assert_eq!(stmt_1.children_bi(),stmt_1_ints);
+    assert_eq!(stmt_1.children_bi(), stmt_1_ints);
 
-    let stmt_1_expected = Assign("x".into(), Some(Div(Box::new(Val(3)), Box::new(Var("y".into())))));
-    assert_eq!(stmt_1.with_children_bi(VecDeque::from([3])),stmt_1_expected);
+    let stmt_1_expected = Assign(
+        "x".into(),
+        Some(Div(Box::new(Val(3)), Box::new(Var("y".into())))),
+    );
+    assert_eq!(
+        stmt_1.with_children_bi(VecDeque::from([3])),
+        stmt_1_expected
+    );
 
-    let stmt_1_actual = stmt_1.descend_bi(Arc::new(move |x: i32| {
-        x+1
-    }));
-    assert_eq!(stmt_1_expected,stmt_1_actual);
+    let stmt_1_actual = stmt_1.descend_bi(Arc::new(move |x: i32| x + 1));
+    assert_eq!(stmt_1_expected, stmt_1_actual);
 
-    // test transform_bi 
-    let stmt_1_actual = stmt_1.transform_bi(Arc::new(move |x: i32| {
-        x+1
-    }));
+    // test transform_bi
+    let stmt_1_actual = stmt_1.transform_bi(Arc::new(move |x: i32| x + 1));
 
-    assert_eq!(stmt_1_expected,stmt_1_actual);
+    assert_eq!(stmt_1_expected, stmt_1_actual);
 }

--- a/uniplate/src/impls.rs
+++ b/uniplate/src/impls.rs
@@ -114,6 +114,21 @@ where
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use crate::Biplate as _;
+
+    #[test]
+    fn option_with_children_bi_test() {
+        let expr = Some(10);
+        let expected = Some(11);
+        let actual: Option<i32> = expr.with_children_bi(VecDeque::from([11]));
+        assert_eq!(actual, expected);
+    }
+}
+
 // TODO: Add results. We might want to somehow make it optional whether we traverse into an error
 // type or not, allowing errors to not implement Uniplate / Biplate.
 //

--- a/uniplate/src/lib.rs
+++ b/uniplate/src/lib.rs
@@ -102,8 +102,25 @@ macro_rules! derive_unplateable {
                 let val = self.clone();
                 (
                     ::uniplate::Tree::One(val.clone()),
-                    Box::new(move |_| val.clone()),
+                    Box::new(move |x| {
+                        let ::uniplate::Tree::One(x) = x else {
+                            panic!();
+                        };
+                        x
+                    }),
                 )
+            }
+        }
+
+        impl ::uniplate::Biplate<Option<$t>> for $t {
+            fn biplate(
+                &self,
+            ) -> (
+                ::uniplate::Tree<Option<$t>>,
+                Box<dyn Fn(::uniplate::Tree<Option<$t>>) -> $t>,
+            ) {
+                let val = self.clone();
+                (::uniplate::Tree::Zero, Box::new(move |_| val.clone()))
             }
         }
     };

--- a/uniplate/src/traits.rs
+++ b/uniplate/src/traits.rs
@@ -95,8 +95,7 @@ where
     ///
     /// Biplate variant of [`Uniplate::transform`]
     fn transform_bi(&self, op: Arc<dyn Fn(To) -> To>) -> Self {
-        let (children, ctx) = self.biplate();
-        ctx(children.map(Arc::new(move |child| child.transform(op.clone()))))
+        self.descend_bi(Arc::new(move |x| x.transform(op.clone())))
     }
 
     /// Returns an iterator over all direct children of the input, paired with a function that


### PR DESCRIPTION
* Fix broken reconstruction function for Biplates of basic types
  (i32,String,etc). In some circumstances, this caused with_children_bi
  / transform_bi, etc. to not apply changes to these types.

* Allow use of <Option<A> as Biplate<A>> for basic types.

* Fix transform_bi. As with basic types, values were not updating
  properly. This now matches the implementation in the Haskell version.
