### PR TITLE
feat: unhide `Tree` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,7 +784,7 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "uniplate"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "criterion",
  "proptest",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "uniplate-derive"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "itertools 0.14.0",
  "lazy_static",

--- a/uniplate/src/lib.rs
+++ b/uniplate/src/lib.rs
@@ -14,7 +14,6 @@ mod tree;
 
 pub use traits::{Biplate, Uniplate};
 
-#[doc(hidden)]
 pub use tree::Tree;
 
 #[doc(hidden)]

--- a/uniplate/src/tree.rs
+++ b/uniplate/src/tree.rs
@@ -1,13 +1,13 @@
-//! `Tree` is used for implementing custom instances.
-//!
-//! See [`Uniplate::uniplate`](super::Uniplate::uniplate),
-//! [`Biplate::biplate`](super::Biplate::biplate)
-
 use std::{collections::VecDeque, sync::Arc};
 
 use self::Tree::*;
 
-/// `Tree` stores the children (of type `T`) of a variable.
+///
+/// `Tree` stores the children of type `T` of a value, preserving its structure.
+///
+/// It is primarily used for implementing [`Uniplate`](super::Uniplate) and
+/// [`Biplate`](super::Biplate) instances.
+///
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Tree<T: Sized + Clone + Eq> {
     /// This element cannot contains no children.


### PR DESCRIPTION
Unhide `Tree` type, making it appear in documentation and LSP suggestions.

It was originally hidden as it is only used inside the implementation of `Uniplate` and `Biplate`; however, having documentation for it is useful for writing manual instances.