### PR TITLE
feat!: move derive macro from `uniplate::derive::Uniplate` to `uniplate::Uniplate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ With Uniplate, this boilerplate can be eliminated:
 ```rust
 use std::collections::VecDeque;
 use uniplate::{Uniplate,Biplate};
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 #[derive(Clone,PartialEq,Eq,Debug,Uniplate)]
 #[uniplate()]
 #[biplate(to=String)]
@@ -127,7 +127,7 @@ variable names used by child expressions.
 ```rust
 use std::collections::VecDeque;
 use uniplate::{Uniplate,Biplate};
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 #[derive(Clone,PartialEq,Eq,Debug,Uniplate)]
 // look for strings inside expressions as well as statements 
 #[biplate(to=String,walk_into=[Expr])]

--- a/uniplate/benches/context.rs
+++ b/uniplate/benches/context.rs
@@ -1,7 +1,7 @@
 //! Benchmarks for `context`,`context_bi`
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use uniplate::{derive::Uniplate, Biplate as _, Uniplate};
+use uniplate::{Biplate as _, Uniplate};
 
 #[derive(PartialEq, Eq, Clone, Uniplate)]
 #[uniplate()]

--- a/uniplate/examples/biplate-stmt.rs
+++ b/uniplate/examples/biplate-stmt.rs
@@ -2,7 +2,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
-use uniplate::{derive::Uniplate, Biplate};
+use uniplate::{Biplate, Uniplate};
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[biplate(to=Expr)]

--- a/uniplate/examples/stmt.rs
+++ b/uniplate/examples/stmt.rs
@@ -2,8 +2,8 @@
 
 use std::collections::VecDeque;
 
-use uniplate::derive::Uniplate;
 use uniplate::Biplate;
+use uniplate::Uniplate;
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[uniplate()]

--- a/uniplate/src/intro.md
+++ b/uniplate/src/intro.md
@@ -90,7 +90,7 @@ The easiest way to use Uniplate is with the derive macro.
 To derive Uniplate instances, use the `#[uniplate]` attribute:
 
 ```rust
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 #[derive(Clone,PartialEq,Eq,Debug,Uniplate)]
 #[uniplate()]
 enum Expr {
@@ -107,7 +107,7 @@ enum Expr {
 To derive Biplate instances, use the `#[biplate]` attribute:
 
 ```rust
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 #[derive(Clone,PartialEq,Eq,Debug,Uniplate)]
 #[biplate(to=String)]
 #[biplate(to=i32)]
@@ -151,7 +151,6 @@ only the variable names directly used inside the statement, but also any
 variable names used by child expressions:
 
 ```rust
-use uniplate::derive::Uniplate;
 use uniplate::{Uniplate,Biplate};
 use std::collections::VecDeque;
 #[derive(Clone,PartialEq,Eq,Debug,Uniplate)]

--- a/uniplate/src/lib.rs
+++ b/uniplate/src/lib.rs
@@ -19,21 +19,18 @@ pub use tree::Tree;
 #[doc(hidden)]
 pub mod test_common;
 
-/// The derive macro.
-pub mod derive {
-    /// The Uniplate derive macro.
-    ///
-    /// The macro supports `structs` (including [tuple
-    /// structs](https://doc.rust-lang.org/stable/reference/items/structs.html#r-items.struct.tuple))
-    /// and `enums`.
-    ///
-    /// Enums with [struct-like
-    /// variants](https://doc.rust-lang.org/stable/reference/items/enumerations.html#r-items.enum.struct-expr)
-    /// are not yet supported.
-    ///
-    /// **See the top level crate documentation for usage details.**
-    pub use uniplate_derive::Uniplate;
-}
+/// The Uniplate derive macro.
+///
+/// The macro supports `structs` (including [tuple
+/// structs](https://doc.rust-lang.org/stable/reference/items/structs.html#r-items.struct.tuple))
+/// and `enums`.
+///
+/// Enums with [struct-like
+/// variants](https://doc.rust-lang.org/stable/reference/items/enumerations.html#r-items.enum.struct-expr)
+/// are not yet supported.
+///
+/// **See the top level crate documentation for usage details.**
+pub use uniplate_derive::Uniplate;
 
 /// Generates [`Biplate`] and [`Uniplate`] instances for an unplateable type.
 ///
@@ -51,7 +48,7 @@ pub mod derive {
 /// The below example uses `Biplate` to get all the `Names` in a binary tree.
 ///
 /// ```
-/// use uniplate::{derive_unplateable,Uniplate,Biplate,derive::Uniplate};
+/// use uniplate::{derive_unplateable,Uniplate,Biplate};
 ///
 /// // If you don't care about the children of a type, use derive_unplateable!
 /// #[derive(Clone,PartialEq,Eq)]

--- a/uniplate/src/test_common/paper.rs
+++ b/uniplate/src/test_common/paper.rs
@@ -1,4 +1,4 @@
-use crate::derive::Uniplate;
+use crate::Uniplate;
 
 // Examples found in the Uniplate paper.
 

--- a/uniplate/tests/derive-pass/conjure_ast.rs
+++ b/uniplate/tests/derive-pass/conjure_ast.rs
@@ -5,7 +5,7 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 #[derive(Clone, Debug, PartialEq, Eq, Uniplate)]
 #[uniplate()]
 #[biplate(to=Constant)]

--- a/uniplate/tests/derive-pass/enums/allow-enum-fields-with-trailing-commas.rs
+++ b/uniplate/tests/derive-pass/enums/allow-enum-fields-with-trailing-commas.rs
@@ -1,4 +1,4 @@
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 #[derive(Uniplate,PartialEq,Eq,Clone)]
 #[uniplate()]

--- a/uniplate/tests/derive-pass/enums/allow-enum-variant-with-no-fields.rs
+++ b/uniplate/tests/derive-pass/enums/allow-enum-variant-with-no-fields.rs
@@ -1,4 +1,4 @@
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 #[derive(Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]
 enum A {

--- a/uniplate/tests/derive-pass/enums/allow-enums-with-trailing-commas.rs
+++ b/uniplate/tests/derive-pass/enums/allow-enums-with-trailing-commas.rs
@@ -1,4 +1,4 @@
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 #[derive(PartialEq,Eq,Clone,Uniplate)]
 #[uniplate()]

--- a/uniplate/tests/derive-pass/enums/biplate-stmt.rs
+++ b/uniplate/tests/derive-pass/enums/biplate-stmt.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use uniplate::{derive::Uniplate, Biplate};
+use uniplate::{Uniplate, Biplate};
 use std::collections::VecDeque;
 use std::sync::Arc;
 

--- a/uniplate/tests/derive-pass/enums/issue-16-biplate-to-vec-expr.rs
+++ b/uniplate/tests/derive-pass/enums/issue-16-biplate-to-vec-expr.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use std::collections::VecDeque;
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 use uniplate::Biplate;
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]

--- a/uniplate/tests/derive-pass/structs/allow-tuple-struct.rs
+++ b/uniplate/tests/derive-pass/structs/allow-tuple-struct.rs
@@ -1,4 +1,4 @@
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 #[derive(Uniplate, PartialEq, Eq, Clone)]
 #[uniplate()]

--- a/uniplate/tests/derive-pass/structs/allow-unit-like.rs
+++ b/uniplate/tests/derive-pass/structs/allow-unit-like.rs
@@ -1,4 +1,4 @@
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 #[derive(Uniplate, PartialEq, Eq, Clone)]
 #[uniplate()]

--- a/uniplate/tests/derive-pass/structs/biplate-struct.rs
+++ b/uniplate/tests/derive-pass/structs/biplate-struct.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use uniplate::{derive::Uniplate, Biplate};
+use uniplate::{Uniplate, Biplate};
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[biplate(to=B)]

--- a/uniplate/tests/derive-pass/structs/issue-16-structs.rs
+++ b/uniplate/tests/derive-pass/structs/issue-16-structs.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use uniplate::{derive::Uniplate, Biplate};
+use uniplate::{Uniplate, Biplate};
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[uniplate()]

--- a/uniplate/tests/derive-pass/structs/naming-conflicts.rs
+++ b/uniplate/tests/derive-pass/structs/naming-conflicts.rs
@@ -1,4 +1,4 @@
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 /// Fields are named to cause conflicts with derive macro internal variable naming
 #[derive(Uniplate, PartialEq, Eq, Clone)]

--- a/uniplate/tests/derive-pass/structs/recursive-structs.rs
+++ b/uniplate/tests/derive-pass/structs/recursive-structs.rs
@@ -1,4 +1,3 @@
-use uniplate::derive::Uniplate;
 use uniplate::Uniplate;
 
 #[derive(Uniplate, PartialEq, Eq, Clone)]

--- a/uniplate/tests/expr_stmt_manual.rs
+++ b/uniplate/tests/expr_stmt_manual.rs
@@ -408,7 +408,7 @@ fn children_bi_multitype() {
 
     assert_eq!(expected_expr_children, children.len());
 
-    println!("{:?}", children);
+    println!("{children:?}");
     let Val(_) = children[0] else { panic!() };
     let Add(_, _) = children[1] else { panic!() };
     let Var(_) = children[2] else { panic!() };
@@ -441,7 +441,7 @@ fn universe_bi_multitype() {
 
     assert_eq!(expected_expr_universe, children.len());
 
-    println!("{:?}", children);
+    println!("{children:?}");
     let Val(_) = children[0] else { panic!() };
     let Add(_, _) = children[1] else { panic!() };
     let Var(_) = children[2] else { panic!() };


### PR DESCRIPTION
Reexport the derive macro as `uniplate::Uniplate` instead of
`uniplate::derive::Uniplate`. As this has the same name of the trait,
this simplifies the imports needed to use Uniplate.

BREAKING CHANGE: replace references to `uniplate::derive::Uniplate` with
`uniplate::Uniplate`.
