### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,26 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,7 +750,6 @@ dependencies = [
  "criterion",
  "proptest",
  "proptest-derive",
- "thiserror",
  "trybuild",
  "uniplate-derive",
 ]
@@ -781,7 +760,6 @@ version = "0.3.0"
 dependencies = [
  "itertools 0.14.0",
  "lazy_static",
- "log",
  "proc-macro2",
  "quote",
  "syn",

--- a/uniplate-derive/Cargo.toml
+++ b/uniplate-derive/Cargo.toml
@@ -25,7 +25,6 @@ syn = { version = "2.0.104", features = [
     "extra-traits",
 ] }
 quote = "1.0.40"
-log = "0.4.27"
 itertools = "0.14.0"
 lazy_static = "1.4.0"
 

--- a/uniplate/Cargo.toml
+++ b/uniplate/Cargo.toml
@@ -21,7 +21,6 @@ name = "context"
 harness=false
 
 [dependencies]
-thiserror = "2.0.12"
 uniplate-derive = { version = "0.3.0", path = "../uniplate-derive" }
 
 [dev-dependencies]


### PR DESCRIPTION
Remove unused dependencies `log` from `uniplate-derive`, and
`this-error` from `uniplate`.
