### PR TITLE
feat!: replace `Arc/Box` closures with `&impl Fn`

### DIFF
--- a/uniplate/benches/context.rs
+++ b/uniplate/benches/context.rs
@@ -117,7 +117,7 @@ fn generate_child(
 fn walk_ctx(e: &MyEnum) -> &MyEnum {
     for (e1, c) in e.contexts() {
         black_box(e1.clone());
-        black_box(c.clone());
+        black_box(&c);
         c(e1); // use context to benchmark it too
     }
     black_box(e)
@@ -127,7 +127,7 @@ fn walk_ctx(e: &MyEnum) -> &MyEnum {
 fn walk_ctx_bi_vec(e: &Vec<MyEnum>) -> &Vec<MyEnum> {
     for (e1, c) in e.contexts_bi() {
         black_box(e1.clone());
-        black_box(c.clone());
+        black_box(&c);
         c(e1); // use context to benchmark it too
     }
     black_box(e)

--- a/uniplate/examples/biplate-stmt.rs
+++ b/uniplate/examples/biplate-stmt.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use std::collections::VecDeque;
-use std::sync::Arc;
 use uniplate::{Biplate, Uniplate};
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
@@ -73,11 +72,11 @@ pub fn main() {
         stmt_1_expected
     );
 
-    let stmt_1_actual = stmt_1.descend_bi(Arc::new(move |x: i32| x + 1));
+    let stmt_1_actual = stmt_1.descend_bi(&|x: i32| x + 1);
     assert_eq!(stmt_1_expected, stmt_1_actual);
 
     // test transform_bi
-    let stmt_1_actual = stmt_1.transform_bi(Arc::new(move |x: i32| x + 1));
+    let stmt_1_actual = stmt_1.transform_bi(&|x: i32| x + 1);
 
     assert_eq!(stmt_1_expected, stmt_1_actual);
 }

--- a/uniplate/src/traits/biplate.rs
+++ b/uniplate/src/traits/biplate.rs
@@ -1,7 +1,7 @@
 use super::holes::HolesIterBi;
 use super::{context::ContextIterBi, Uniplate};
 
-use std::{collections::VecDeque, sync::Arc};
+use std::collections::VecDeque;
 
 pub use crate::Tree;
 /// `Biplate<U>` for type `T` operates over all values of type `U` within `T`.
@@ -51,7 +51,7 @@ where
     /// is highly unlikely that this function should be used in the recursive case. A common
     /// pattern is to first match the types using descend_bi, then continue the recursion with
     /// descend.
-    fn descend_bi(&self, op: Arc<dyn Fn(To) -> To>) -> Self {
+    fn descend_bi(&self, op: &impl Fn(To) -> To) -> Self {
         let (children, ctx) = self.biplate();
         ctx(children.map(op))
     }
@@ -88,15 +88,15 @@ where
     /// Applies the given function to all nodes bottom up.
     ///
     /// Biplate variant of [`Uniplate::transform`]
-    fn transform_bi(&self, op: Arc<dyn Fn(To) -> To>) -> Self {
-        self.descend_bi(Arc::new(move |x| x.transform(op.clone())))
+    fn transform_bi(&self, op: &impl Fn(To) -> To) -> Self {
+        self.descend_bi(&|x| x.transform(op))
     }
 
     /// Returns an iterator over all direct children of the input, paired with a function that
     /// "fills the hole" where the child was with a new value.
     ///
     /// `Biplate` variant of [`Uniplate::holes`]
-    fn holes_bi(&self) -> impl Iterator<Item = (To, Arc<dyn Fn(To) -> Self>)> {
+    fn holes_bi(&self) -> impl Iterator<Item = (To, impl Fn(To) -> Self)> {
         // must be an iterator as we cannot clone Box<dyn Fn()>'s, so cannot stick them in
         // vectors, etc
         HolesIterBi::new(self.clone())
@@ -109,7 +109,7 @@ where
     ///
     /// To efficiently update multiple values in a single traversal, use
     /// [`ZipperBi`](crate::zipper::ZipperBi) instead.
-    fn contexts_bi(&self) -> impl Iterator<Item = (To, Arc<dyn Fn(To) -> Self>)> {
+    fn contexts_bi(&self) -> impl Iterator<Item = (To, impl Fn(To) -> Self)> {
         ContextIterBi::new(self.clone())
     }
 }

--- a/uniplate/src/traits/context.rs
+++ b/uniplate/src/traits/context.rs
@@ -1,6 +1,4 @@
-//! The underlying iterator for `Uniplate::context()`
-
-use std::sync::Arc;
+//! The underlying iterator for `Uniplate::context()`cionte
 
 use crate::zipper::{Zipper, ZipperBi};
 
@@ -22,7 +20,7 @@ impl<T: Uniplate> ContextIter<T> {
 }
 
 impl<T: Uniplate> Iterator for ContextIter<T> {
-    type Item = (T, Arc<dyn Fn(T) -> T>);
+    type Item = (T, Box<dyn Fn(T) -> T>);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
@@ -30,7 +28,7 @@ impl<T: Uniplate> Iterator for ContextIter<T> {
         };
         let node = self.zipper.focus().clone();
         let zipper1 = self.zipper.clone();
-        let hole_fn = Arc::new(move |x| {
+        let hole_fn = Box::new(move |x| {
             // TODO: if performance is still an issue, maybe we could make this a single call function
             // (FnOnce) then we wouldn't need to clone as much?
             let mut zipper2 = zipper1.clone();
@@ -70,7 +68,7 @@ impl<T: Uniplate, U: Biplate<T>> ContextIterBi<T, U> {
 }
 
 impl<T: Uniplate, U: Biplate<T>> Iterator for ContextIterBi<T, U> {
-    type Item = (T, Arc<dyn Fn(T) -> U>);
+    type Item = (T, Box<dyn Fn(T) -> U>);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
@@ -84,7 +82,7 @@ impl<T: Uniplate, U: Biplate<T>> Iterator for ContextIterBi<T, U> {
         let node = zipper.focus().clone();
 
         let zipper1 = zipper.clone();
-        let hole_fn = Arc::new(move |x| {
+        let hole_fn = Box::new(move |x| {
             // TODO: if performance is still an issue, maybe we could make this a single call function
             // (FnOnce) then we wouldn't need to clone as much?
             let mut zipper1 = zipper1.clone();

--- a/uniplate/src/traits/holes.rs
+++ b/uniplate/src/traits/holes.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::collections::VecDeque;
 
 use super::{Biplate, Uniplate};
 
@@ -9,14 +9,14 @@ pub(super) struct HolesIter<T: Uniplate> {
 }
 
 impl<T: Uniplate> Iterator for HolesIter<T> {
-    type Item = (T, Arc<dyn Fn(T) -> T>);
+    type Item = (T, Box<dyn Fn(T) -> T>);
 
     fn next(&mut self) -> Option<Self::Item> {
         let (i, child) = self.children_iter.next()?;
 
         let children2 = self.children.clone();
         let parent2 = self.parent.clone();
-        let hole = Arc::new(move |x: T| {
+        let hole = Box::new(move |x: T| {
             let mut children = children2.clone();
             children[i] = x;
             parent2.with_children(children)
@@ -46,14 +46,14 @@ pub(super) struct HolesIterBi<T: Uniplate, F: Biplate<T>> {
 }
 
 impl<T: Uniplate, F: Biplate<T>> Iterator for HolesIterBi<T, F> {
-    type Item = (T, Arc<dyn Fn(T) -> F>);
+    type Item = (T, Box<dyn Fn(T) -> F>);
 
     fn next(&mut self) -> Option<Self::Item> {
         let (i, child) = self.children_iter.next()?;
 
         let children2 = self.children.clone();
         let parent2 = self.parent.clone();
-        let hole = Arc::new(move |x: T| {
+        let hole = Box::new(move |x: T| {
             let mut children = children2.clone();
             children[i] = x;
             parent2.with_children_bi(children)

--- a/uniplate/src/tree.rs
+++ b/uniplate/src/tree.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::collections::VecDeque;
 
 use self::Tree::*;
 
@@ -82,11 +82,11 @@ impl<T: Sized + Clone + Eq + 'static> Tree<T> {
     }
 
     /// Applies a function over all elements in the tree.
-    pub fn map(self, op: Arc<dyn Fn(T) -> T>) -> Tree<T> {
+    pub fn map(self, op: &impl Fn(T) -> T) -> Tree<T> {
         match self {
             Zero => Zero,
             One(t) => One(op(t)),
-            Many(ts) => Many(ts.into_iter().map(|t| t.map(op.clone())).collect()),
+            Many(ts) => Many(ts.into_iter().map(|t| t.map(op)).collect::<_>()),
         }
     }
 }
@@ -125,7 +125,7 @@ mod tests {
 
         #[test]
         fn map_add(tree in proptest_integer_trees(), diff in -100i32..100i32) {
-            let new_tree = tree.clone().map(Arc::new(move |a| a+diff));
+            let new_tree = tree.clone().map(&|a| a+diff);
             let (old_children,_) = tree.list();
             let (new_children,_) = new_tree.list();
 

--- a/uniplate/tests/derive-pass/enums/biplate-stmt.rs
+++ b/uniplate/tests/derive-pass/enums/biplate-stmt.rs
@@ -2,7 +2,6 @@
 
 use uniplate::{Uniplate, Biplate};
 use std::collections::VecDeque;
-use std::sync::Arc;
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[biplate(to=Expr)]
@@ -64,15 +63,15 @@ pub fn main() {
     let stmt_1_expected = Assign("x".into(), Some(Div(Box::new(Val(3)), Box::new(Var("y".into())))));
     assert_eq!(stmt_1.with_children_bi(VecDeque::from([3])),stmt_1_expected);
 
-    let stmt_1_actual = stmt_1.descend_bi(Arc::new(move |x: i32| {
+    let stmt_1_actual = stmt_1.descend_bi(&|x: i32| {
         x+1
-    }));
+    });
     assert_eq!(stmt_1_expected,stmt_1_actual);
 
     // test transform_bi 
-    let stmt_1_actual = stmt_1.transform_bi(Arc::new(move |x: i32| {
+    let stmt_1_actual = stmt_1.transform_bi(&|x: i32| {
         x+1
-    }));
+    });
 
     assert_eq!(stmt_1_expected,stmt_1_actual);
 }


### PR DESCRIPTION
Change types of `Uniplate` and `Biplate` methods to use `&impl Fn` instead of `Box<dyn Fn...>` and `Arc<dyn Fn...>`.

This makes the API simpler to use: previously you would have to do `foo.transform(Arc::new(|x|  ...))`, now you can do `foo.transform(&|x| ...)`. Also, this allows function pointers to be used in Uniplate method.

While performance was not the aim of this change, nonetheless it improves performance by a few percentage points for some of the benchmarks.

BREAKING CHANGE: Uniplate and Biplate methods that take `Arc<dyn Fn...>` parameters now take `&impl Fn...` instead. Instead of `foo.transform(Arc::new(|x| ...))`, use `foo.transform(&|x| ...)`.

BREAKING CHANGE: `Uniplate::holes`, `Uniplate::contexts` now return a closure of type `impl Fn(Self) -> Self` instead of `Arc<dyn Fn(Self) -> Self>`.

BREAKING CHANGE: `Biplate::holes_bi`, `Uniplate::contexts_bi` now return a closure of type `impl Fn(To) -> Self` instead of `Arc<dyn Fn(To) -> Self>`.
