### PR TITLE
feat(derive): support simple generic type parameters

### DIFF
--- a/uniplate-derive/build.rs
+++ b/uniplate-derive/build.rs
@@ -1,0 +1,3 @@
+pub fn main() {
+    println!("cargo::rustc-check-cfg=cfg(uniplate_trace, values(\"walkinto\"))");
+}

--- a/uniplate-derive/src/ast/derive_input.rs
+++ b/uniplate-derive/src/ast/derive_input.rs
@@ -92,6 +92,8 @@ impl InstanceMeta {
         };
 
         for typ2 in walk_into {
+            let typ1_basetyp = typ.base_typ();
+            let typ2_basetyp = typ2.base_typ();
             if typ.base_typ() == typ2.base_typ() {
                 return true;
             }

--- a/uniplate-derive/src/ast/derive_input.rs
+++ b/uniplate-derive/src/ast/derive_input.rs
@@ -92,8 +92,6 @@ impl InstanceMeta {
         };
 
         for typ2 in walk_into {
-            let typ1_basetyp = typ.base_typ();
-            let typ2_basetyp = typ2.base_typ();
             if typ.base_typ() == typ2.base_typ() {
                 return true;
             }

--- a/uniplate-derive/src/ast/typ.rs
+++ b/uniplate-derive/src/ast/typ.rs
@@ -91,7 +91,10 @@ impl Parse for Type {
                     "Biplate: expected type argument here",
                 ));
             };
+            // remove box from the base and wrapper paths, as we store that a type is boxed
+            // seperately.
             base_path = typ2.path.clone();
+            wrapper_path = Some(base_path.clone());
 
             any_args = false;
         }
@@ -145,7 +148,6 @@ impl Parse for Type {
                 box_type = new_box_type;
 
                 wrapper_path = Some(base_path.clone());
-                any_args = false;
             }
         }
 

--- a/uniplate/tests/derive-pass/generics/tree-biplate.rs
+++ b/uniplate/tests/derive-pass/generics/tree-biplate.rs
@@ -1,0 +1,49 @@
+#![allow(dead_code)]
+//! Using derive with a simple container type (a binary tree)
+
+use std::collections::VecDeque;
+
+// Using a mix of where clauses and type parameter bounds, to show that either works.
+//
+// Note that Uniplate does not walk into T here.
+use uniplate::{Biplate, Uniplate};
+#[derive(Eq, PartialEq, Uniplate, Clone)]
+#[biplate(to=T)]
+enum BinaryTree<T: PartialEq + Eq>
+where
+    T: Ord,
+    T: Clone,
+{
+    Leaf(T),
+    Branch(T, Box<BinaryTree<T>>, Box<BinaryTree<T>>),
+}
+
+pub fn main() {
+    let tree1: BinaryTree<String> = BinaryTree::Leaf("Hello".into());
+    let tree2: BinaryTree<String> = BinaryTree::Branch(
+        "World".into(),
+        Box::new(tree1.clone()),
+        Box::new(tree1.clone()),
+    );
+    let tree3: BinaryTree<String> = BinaryTree::Branch(
+        "Foo".into(),
+        Box::new(tree1.clone()),
+        Box::new(tree2.clone()),
+    );
+
+    let tree1_universe: VecDeque<String> = VecDeque::from(["Hello".into()]);
+    let tree2_universe: VecDeque<String> =
+        VecDeque::from(["World".into(), "Hello".into(), "Hello".into()]);
+
+    let tree3_universe: VecDeque<String> = VecDeque::from([
+        "Foo".into(),
+        "Hello".into(),
+        "World".into(),
+        "Hello".into(),
+        "Hello".into(),
+    ]);
+
+    assert_eq!(tree1_universe, Biplate::<String>::universe_bi(&tree1));
+    assert_eq!(tree2_universe, Biplate::<String>::universe_bi(&tree2));
+    assert_eq!(tree3_universe, Biplate::<String>::universe_bi(&tree3));
+}

--- a/uniplate/tests/derive-pass/generics/tree-biplate2.rs
+++ b/uniplate/tests/derive-pass/generics/tree-biplate2.rs
@@ -1,0 +1,55 @@
+#![allow(dead_code)]
+//! Using derive with a simple container type (a binary tree)
+
+use std::collections::VecDeque;
+
+// Using a mix of where clauses and type parameter bounds, to show that either works.
+//
+// Note that Uniplate does not walk into T here.
+use uniplate::{Biplate, Uniplate};
+#[derive(Eq, PartialEq, Uniplate, Clone)]
+#[biplate(to=String, walk_into=[T])]
+enum BinaryTree<T: PartialEq + Eq>
+where
+    T: Clone,
+{
+    Leaf(T),
+    Branch(T, Box<BinaryTree<T>>, Box<BinaryTree<T>>),
+}
+
+#[derive(Eq, PartialEq, Clone, Uniplate)]
+#[biplate(to=String)]
+enum Foo {
+    A(String),
+    B(i32),
+}
+
+pub fn main() {
+    let tree1: BinaryTree<Foo> = BinaryTree::Leaf(Foo::A("Hello".into()));
+    let tree2: BinaryTree<Foo> = BinaryTree::Branch(
+        Foo::A("World".into()),
+        Box::new(tree1.clone()),
+        Box::new(tree1.clone()),
+    );
+    let tree3: BinaryTree<Foo> = BinaryTree::Branch(
+        Foo::A("Foo".into()),
+        Box::new(tree1.clone()),
+        Box::new(tree2.clone()),
+    );
+
+    let tree1_universe: VecDeque<String> = VecDeque::from(["Hello".into()]);
+    let tree2_universe: VecDeque<String> =
+        VecDeque::from(["World".into(), "Hello".into(), "Hello".into()]);
+
+    let tree3_universe: VecDeque<String> = VecDeque::from([
+        "Foo".into(),
+        "Hello".into(),
+        "World".into(),
+        "Hello".into(),
+        "Hello".into(),
+    ]);
+
+    assert_eq!(tree1_universe, Biplate::<String>::universe_bi(&tree1));
+    assert_eq!(tree2_universe, Biplate::<String>::universe_bi(&tree2));
+    assert_eq!(tree3_universe, Biplate::<String>::universe_bi(&tree3));
+}

--- a/uniplate/tests/derive-pass/generics/tree-uniplate-walk-into.rs
+++ b/uniplate/tests/derive-pass/generics/tree-uniplate-walk-into.rs
@@ -1,0 +1,18 @@
+#![allow(dead_code)]
+//! Using derive with a simple container type (a binary tree)
+
+// Using a mix of where clauses and type parameter bounds, to show that either works.
+//
+use uniplate::Uniplate;
+#[derive(Eq, PartialEq, Uniplate, Clone)]
+#[uniplate(walk_into=[T])]
+enum BinaryTree<T: PartialEq + Eq>
+where
+    T: Ord,
+    T: Clone,
+{
+    Leaf(T),
+    Branch(T, Box<BinaryTree<T>>, Box<BinaryTree<T>>),
+}
+
+pub fn main() {}

--- a/uniplate/tests/derive-pass/generics/tree.rs
+++ b/uniplate/tests/derive-pass/generics/tree.rs
@@ -1,0 +1,19 @@
+#![allow(dead_code)]
+//! Using derive with a simple container type (a binary tree)
+
+// Using a mix of where clauses and type parameter bounds, to show that either works.
+//
+// Note that Uniplate does not walk into T here.
+use uniplate::Uniplate;
+#[derive(Eq, PartialEq, Uniplate, Clone)]
+#[uniplate()]
+enum BinaryTree<T: PartialEq + Eq>
+where
+    T: Ord,
+    T: Clone,
+{
+    Leaf(T),
+    Branch(T, Box<BinaryTree<T>>, Box<BinaryTree<T>>),
+}
+
+pub fn main() {}


### PR DESCRIPTION
Add parsing for generic parameters and where blocks to the derive maro.

Support deriving of Uniplate on container types with a generic type parameters, bounds, and where blocks.

While lifetimes parse successfully, there are some unresolved code-gen issues with them - this will be addressed in future work.

## Details

For example, we can now derive the following:

```rs
#[derive(Clone,Uniplate)]
#[uniplate(walk_into=T)]
#[biplate(to=String, walk_into=[T])]
enum BinaryTree<T: Clone> where T: Ord + PartialEq + Eq {
  Leaf(T),
  Branch(T,Box<BinaryTree<T>>,Box<BinaryTree<T>>)
}
```

To avoid making the user add Uniplate related bounds to the generic types, such as `T: Uniplate`, we add these bounds to the impl instead.

For all implementations, `T: 'static` is added, as this is required for `Uniplate` and `Biplate`.If we need to walk into `T` more bounds are added; for example, if we want to walk into `T` for the impl `Uniplate for BinaryTree<T>`, we add the additional bound `T: Biplate<BinaryTree<T>>` to the impl.

For example, for the above, we would generate a `Biplate<String>` impl that begins like so:

```rs
impl<T: Clone + 'static + Biplate<String>>
Biplate<String> for BinaryTree<T> where T: Ord + PartialEq + Eq {
# ...
```

## Known issues

* Code generation for lifetimes doesn't work yet.

* Deriving biplate instances where the destination type is a generic parameter can break.

  For example, this does not compile:

  ```rs
    #[derive(Clone,Uniplate)]
    #[uniplate(walk_into=T)]
    #[biplate(to=T)]
    #[biplate(to=String)]
    enum BinaryTree<T: Clone> where T: Ord + PartialEq + Eq {
      Leaf(T),
      Branch(T,Box<BinaryTree<T>>,Box<BinaryTree<T>>)
    }
  ```

   Because `T` can include `String`, this results in multiple conflicting implementations of `Biplate` for `String`: the instance `Biplate<T> for BinaryTree<T>`, and the instance `Biplate<String> for BinaryTree<T>`.

  We can't really fix this, as Rust cannot do trait specialisation yet. Perhaps auto-trait deref specialisation (as used in `facet`, etc.) might fix this? Otherwise, the best we can do is to document this limitation.
