### PR TITLE
(derive) Remove `walk_into`, automatically work out which types to walk into

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ fn vars_names(expr: &Expr) -> Vec<String>{
 ```
 
 
-Uniplate also supports trees with multiple recursive types. Lets extend our
+Uniplate also supports trees with multiple nested types. Lets extend our
 calculator language to include statements as well as expressions:
 
 ```rust
@@ -121,16 +121,14 @@ enum Stmt {
 
 When looking for variable names in a given statement, we want to identify not
 only the variable names directly used inside the statement, but also any
-variable names used by child expressions.
-
+variable names used by child expressions:
 
 ```rust
 use std::collections::VecDeque;
 use uniplate::{Uniplate,Biplate};
 use uniplate::Uniplate;
 #[derive(Clone,PartialEq,Eq,Debug,Uniplate)]
-// look for strings inside expressions as well as statements 
-#[biplate(to=String,walk_into=[Expr])]
+#[biplate(to=String)]
 #[biplate(to=Expr)]
 #[uniplate()]
 enum Stmt {
@@ -160,8 +158,6 @@ fn vars_names(stmt: &Stmt) -> Vec<String>{
 
 ```
 
-Despite having to recursively look through multiple types, this operation is
-no harder to write!
 
 
 ## Acknowledgements

--- a/uniplate-derive/src/ast/typ.rs
+++ b/uniplate-derive/src/ast/typ.rs
@@ -27,6 +27,7 @@ pub enum Type {
 }
 
 impl Type {
+    #[allow(dead_code)]
     pub fn base_typ(&self) -> Option<syn::Path> {
         match self {
             Type::BoxedPlateable(x) => Some(x.base_typ()),

--- a/uniplate-derive/src/state.rs
+++ b/uniplate-derive/src/state.rs
@@ -1,9 +1,7 @@
 //! Global(ish) Parser State variables
 
-use crate::{ast::InstanceMeta, prelude::*};
+use crate::prelude::*;
 use std::collections::VecDeque;
-
-use self::ast::HasBaseType;
 
 /// State variables for biplate derive.
 #[derive(Debug)]
@@ -37,7 +35,6 @@ impl ParserState {
         // always generate Biplate<From,From>
         instances_to_generate.push_front(ast::InstanceMeta::Biplate(ast::BiplateInstanceMeta {
             to: ast::Type::Plateable(from.clone()),
-            walk_into: Vec::new(),
         }));
 
         Self {
@@ -74,106 +71,5 @@ impl ParserState {
         self.current_instance.as_ref()?;
 
         Some(())
-    }
-
-    /// Checks if a type can be walked into or not
-    ///
-    /// This acts similarly to ast::InstanceMeta::walk_into_type but also considers the
-    /// current to and from type as walkable.
-    pub fn walk_into_type(&self, typ: &ast::Type) -> bool {
-        let res = self.walk_into_type_inner(typ);
-        // trace walk_into calls if cfg value uniplate_trace = "walkinto" is set
-        //
-        // to enable it on build: RUSTFLAGS='--cfg=uniplate_trace="walkinto"' cargo ...
-        if cfg!(uniplate_trace = "walkinto") {
-            let from = &self.from;
-            let to = &self.to;
-            if res {
-                eprintln!(
-                    "[walk-into+] Instance from {from} to {to}: walking into type {typ}",
-                    from = quote!(#from),
-                    to = quote!(#to),
-                    typ = quote!(#typ)
-                );
-            } else {
-                let from_basetype = from.base_typ();
-                let to_basetype = to.clone().unwrap().base_typ();
-                eprintln!(
-                    "[walk-into-] Instance from {from} to {to}: NOT walking into type {typ}",
-                    from = quote!(#from),
-                    to = quote!(#to),
-                    typ = quote!(#typ)
-                );
-                eprintln!(
-                    "             .. from base type is {}",
-                    quote!(#from_basetype)
-                );
-                eprintln!("             .. to base type is {}", quote!(#to_basetype));
-                match typ {
-                    ast::Type::BoxedPlateable(boxed_plateable_type) => {
-                        let box_type = &boxed_plateable_type.box_typ;
-                        let wrapper_type = &boxed_plateable_type.inner_typ.wrapper_typ;
-                        let base_type = &boxed_plateable_type.inner_typ.base_typ;
-                        eprintln!("             .. target type is a boxed plateable type");
-                        eprintln!("             .. box type is {}", quote!(#box_type));
-                        eprintln!("             .. wrapper type is {}", quote!(#wrapper_type));
-                        eprintln!("             .. base type is {}", quote!(#base_type));
-                    }
-                    ast::Type::Plateable(plateable_type) => {
-                        let wrapper_type = &plateable_type.wrapper_typ;
-                        let base_type = &plateable_type.base_typ;
-                        eprintln!("             .. target type is a plateable type");
-                        eprintln!("             .. wrapper type is {}", quote!(#wrapper_type));
-                        eprintln!("             .. base type is {}", quote!(#base_type));
-                    }
-                    ast::Type::Unplateable => {
-                        eprintln!("             .. target type is an unplateable type")
-                    }
-                }
-            }
-        }
-
-        res
-    }
-
-    #[inline(always)]
-    fn walk_into_type_inner(&self, typ: &ast::Type) -> bool {
-        let Some(base_typ) = typ.base_typ() else {
-            return false;
-        };
-
-        if base_typ == self.to.clone().expect("").base_typ() {
-            return true;
-        };
-
-        if base_typ == self.from.base_typ() {
-            return true;
-        };
-
-        self.current_instance.clone().expect("").walk_into_type(typ)
-    }
-
-    /// Returns a reference to the uniplate instance
-    ///
-    /// # Panics
-    ///
-    /// If there are more than one uniplate instances
-    pub fn get_uniplate_instance(&self) -> &InstanceMeta {
-        if let Some(instance @ InstanceMeta::Uniplate(_)) = &self.current_instance {
-            return instance;
-        } else {
-            for instance in &self.instances_to_generate {
-                if let InstanceMeta::Uniplate(_) = instance {
-                    return instance;
-                }
-            }
-
-            for instance in &self.instances_generated {
-                if let InstanceMeta::Uniplate(_) = &instance {
-                    return instance;
-                }
-            }
-        }
-        unreachable!();
     }
 }

--- a/uniplate/examples/biplate-stmt.rs
+++ b/uniplate/examples/biplate-stmt.rs
@@ -5,10 +5,10 @@ use uniplate::{Biplate, Uniplate};
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[biplate(to=Expr)]
-#[biplate(to=i32,walk_into=[Expr,Option<Expr>])]
+#[biplate(to=i32)]
+#[biplate(to=String)]
 #[biplate(to=Option<Expr>)]
-#[biplate(to=String,walk_into=[Expr])]
-#[uniplate(walk_into=[Expr])]
+#[uniplate()]
 enum Stmt {
     Assign(String, Option<Expr>),
     Sequence(Vec<Stmt>),
@@ -17,7 +17,7 @@ enum Stmt {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
-#[uniplate(walk_into=[Stmt])]
+#[uniplate()]
 #[biplate(to=String)]
 #[biplate(to=Option<Expr>)]
 #[biplate(to=Stmt)]

--- a/uniplate/examples/stmt.rs
+++ b/uniplate/examples/stmt.rs
@@ -7,7 +7,7 @@ use uniplate::Uniplate;
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[uniplate()]
-#[biplate(to=String,walk_into=[Expr])]
+#[biplate(to=String)]
 enum Stmt {
     Nothing,
     Assign(String, Expr),

--- a/uniplate/examples/tree-biplate.rs
+++ b/uniplate/examples/tree-biplate.rs
@@ -4,34 +4,29 @@
 use std::collections::VecDeque;
 
 // Using a mix of where clauses and type parameter bounds, to show that either works.
+//
+// Note that Uniplate does not walk into T here.
 use uniplate::{Biplate, Uniplate};
 #[derive(Eq, PartialEq, Uniplate, Clone)]
-#[biplate(to=String)]
+#[biplate(to=T)]
 enum BinaryTree<T: PartialEq + Eq>
 where
+    T: Ord,
     T: Clone,
-    T: Biplate<String>, // we must require this for biplate to look inside T for strings
 {
     Leaf(T),
     Branch(T, Box<BinaryTree<T>>, Box<BinaryTree<T>>),
 }
 
-#[derive(Eq, PartialEq, Clone, Uniplate)]
-#[biplate(to=String)]
-enum Foo {
-    A(String),
-    B(i32),
-}
-
 pub fn main() {
-    let tree1: BinaryTree<Foo> = BinaryTree::Leaf(Foo::A("Hello".into()));
-    let tree2: BinaryTree<Foo> = BinaryTree::Branch(
-        Foo::A("World".into()),
+    let tree1: BinaryTree<String> = BinaryTree::Leaf("Hello".into());
+    let tree2: BinaryTree<String> = BinaryTree::Branch(
+        "World".into(),
         Box::new(tree1.clone()),
         Box::new(tree1.clone()),
     );
-    let tree3: BinaryTree<Foo> = BinaryTree::Branch(
-        Foo::A("Foo".into()),
+    let tree3: BinaryTree<String> = BinaryTree::Branch(
+        "Foo".into(),
         Box::new(tree1.clone()),
         Box::new(tree2.clone()),
     );

--- a/uniplate/src/intro.md
+++ b/uniplate/src/intro.md
@@ -124,7 +124,7 @@ enum Expr {
 
 ## Multi-type traversals
 
-Uniplate also supports trees with multiple recursive types. Lets extend our
+Uniplate also supports trees with multiple nested types. Lets extend our
 calculator language to include statements as well as expressions:
 
 ```rust
@@ -154,8 +154,7 @@ variable names used by child expressions:
 use uniplate::{Uniplate,Biplate};
 use std::collections::VecDeque;
 #[derive(Clone,PartialEq,Eq,Debug,Uniplate)]
-// look for strings inside expressions as well as statements 
-#[biplate(to=String,walk_into=[Expr])]
+#[biplate(to=String)]
 #[biplate(to=Expr)]
 #[uniplate()]
 enum Stmt {
@@ -183,10 +182,6 @@ fn vars_names(stmt: &Stmt) -> Vec<String>{
     names.into()
 }
 ```
-
-The types given to the `walk_into` argument are recursed through by uniplate.
-Both `#[uniplate]` and `#[biplate]` support the `walk_into` parameter.
-
 
 # Bibliography
 

--- a/uniplate/src/lib.rs
+++ b/uniplate/src/lib.rs
@@ -7,6 +7,7 @@ extern crate self as uniplate;
 #[doc(hidden)]
 pub mod impls;
 
+pub mod spez;
 pub mod tagged_zipper;
 pub mod zipper;
 

--- a/uniplate/src/spez.rs
+++ b/uniplate/src/spez.rs
@@ -1,0 +1,238 @@
+//! Auto-deref specialization helpers for the derive macro.
+#![allow(clippy::type_complexity)]
+
+use std::{any::TypeId, marker::PhantomData};
+
+use crate::{Biplate, Tree, Uniplate};
+
+/// A wrapper type used for auto-deref specialisation of `Biplate`.
+///
+/// The `Dest` type stores the destination type of the `Biplate` operation. That is,
+/// `SpezBiplate<Src,Dest>` trys to call the implementation `Biplate<Dest> for Src`.
+///
+/// This is used alongside the [`BiplateYes`] and [`BiplateNo`] traits to do specialization of
+/// Biplate calls in the derive macro.
+pub struct SpezBiplate<Src, Dest>(pub Src, pub PhantomData<Dest>);
+
+/// Specialization proxy for [`uniplate::Biplate`].
+pub trait BiplateYes {
+    /// The source type.
+    type Src;
+    /// The destination type of the biplate operation.
+    type Dest: Eq + Clone;
+
+    /// Calls `Biplate<Dest>` on the inner value.
+    ///
+    /// This method is called when the wrapped type implements `Biplate<Dest>`.
+    fn spez_try_biplate(&self) -> (Tree<Self::Dest>, Box<dyn Fn(Tree<Self::Dest>) -> Self::Src>);
+
+    #[allow(missing_docs)]
+    fn spez_impls_biplate(&self) -> bool;
+}
+
+/// Specialization proxy for [`uniplate::Biplate`].
+pub trait BiplateNo {
+    /// The source type.
+    type Src;
+    /// The destination type of the biplate operation.
+    type Dest: Eq + Clone;
+
+    /// Fallback implementation used when the inner value doesn't implement `Biplate<Dest>`.
+    fn spez_try_biplate(&self) -> (Tree<Self::Dest>, Box<dyn Fn(Tree<Self::Dest>) -> Self::Src>);
+
+    #[allow(missing_docs)]
+    fn spez_impls_biplate(&self) -> bool;
+}
+
+// Implementation of specialisation.
+
+impl<Src, Dest> BiplateYes for &SpezBiplate<Src, Dest>
+where
+    Src: Biplate<Dest>,
+    Dest: Eq + Clone + Uniplate,
+{
+    type Src = Src;
+    type Dest = Dest;
+
+    fn spez_try_biplate(&self) -> (Tree<Self::Dest>, Box<dyn Fn(Tree<Self::Dest>) -> Self::Src>) {
+        self.0.biplate()
+    }
+
+    #[inline(always)]
+    fn spez_impls_biplate(&self) -> bool {
+        true
+    }
+}
+
+impl<Src, Dest> BiplateNo for SpezBiplate<Src, Dest>
+where
+    Src: Eq + Clone + 'static,
+    Dest: Eq + Clone + 'static,
+{
+    type Src = Src;
+    type Dest = Dest;
+
+    fn spez_try_biplate(&self) -> (Tree<Self::Dest>, Box<dyn Fn(Tree<Self::Dest>) -> Self::Src>) {
+        // Biplate<T> for T returns self, not immediate childreen
+        if TypeId::of::<Src>() == TypeId::of::<Dest>() {
+            unsafe {
+                let this_as_dest: Dest = (std::mem::transmute::<&Src, &Dest>(&self.0)).clone();
+
+                let tree = Tree::One(this_as_dest);
+                let ctx = Box::new(move |x| {
+                    let Tree::One(x) = x else {
+                        panic!();
+                    };
+
+                    std::mem::transmute::<&Dest, &Src>(&x).clone()
+                });
+
+                (tree, ctx)
+            }
+        } else {
+            let this = self.0.clone();
+            (Tree::Zero, Box::new(move |_| this.clone()))
+        }
+    }
+
+    #[inline(always)]
+    fn spez_impls_biplate(&self) -> bool {
+        false
+    }
+}
+
+#[doc(inline)]
+/// Tries to call `Biplate<$t>::biplate` on `$x`, returning a default implementation if `$x` does
+/// not implement `Biplate<$t>`.
+pub use super::try_biplate_to;
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! try_biplate_to {
+    ($x:expr,$t:ty) => {{
+        #[allow(unused_imports)]
+        use ::uniplate::spez::{BiplateNo, BiplateYes, SpezBiplate};
+        #[allow(clippy::needless_borrow)]
+        (&&SpezBiplate($x, std::marker::PhantomData::<$t>)).spez_try_biplate()
+    }};
+}
+
+#[doc(inline)]
+/// Returns whether `x` implements `Biplate<$t>`.
+///
+/// ```
+/// use uniplate::{spez::impls_biplate_to,Uniplate};
+///
+/// #[derive(Clone,PartialEq,Eq,Uniplate)]
+/// #[biplate(to=String)]
+/// enum Expr {
+///  A(String)
+/// }
+///
+/// assert!(!impls_biplate_to!(String::from("foo"),i32));
+/// assert!(impls_biplate_to!(String::from("foo"),String));
+/// assert!(impls_biplate_to!(Expr::A(String::from("foo")),String));
+/// ```
+pub use super::impls_biplate_to;
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impls_biplate_to {
+    ($x:expr,$t:ty) => {{
+        #[allow(unused_imports)]
+        use ::uniplate::spez::{BiplateNo as _, BiplateYes as _, SpezBiplate};
+        #[allow(clippy::needless_borrow)]
+        (&&SpezBiplate($x, std::marker::PhantomData::<$t>)).spez_impls_biplate()
+    }};
+}
+
+/// A wrapper type used for auto-deref specialisation of `Uniplate`.
+pub struct SpezUniplate<Src>(pub Src);
+
+/// Specialization proxy for [`uniplate::Uniplate`].
+pub trait UniplateYes {
+    /// The type to perform the Uniplate operation on.
+    type T: Eq + Clone;
+
+    /// Calls `Uniplate` on the inner value.
+    ///
+    /// This method is called when the wrapped type implements `Uniplate`.
+    fn spez_try_uniplate(&self) -> (Tree<Self::T>, Box<dyn Fn(Tree<Self::T>) -> Self::T>);
+
+    #[allow(missing_docs)]
+    fn spez_impls_uniplate(&self) -> bool;
+}
+
+/// Specialization proxy for [`uniplate::Uniplate`].
+pub trait UniplateNo {
+    /// The type to perform the Uniplate operation on.
+    type T: Eq + Clone;
+
+    /// Fallback implementation used when the inner value doesn't implement `Uniplate`.
+    fn spez_try_uniplate(&self) -> (Tree<Self::T>, Box<dyn Fn(Tree<Self::T>) -> Self::T>);
+
+    #[allow(missing_docs)]
+    fn spez_impls_uniplate(&self) -> bool;
+}
+
+impl<T> UniplateYes for &SpezUniplate<T>
+where
+    T: Eq + Clone + Uniplate,
+{
+    type T = T;
+
+    fn spez_try_uniplate(&self) -> (Tree<Self::T>, Box<dyn Fn(Tree<Self::T>) -> Self::T>) {
+        self.0.uniplate()
+    }
+
+    #[inline(always)]
+    fn spez_impls_uniplate(&self) -> bool {
+        true
+    }
+}
+
+impl<T> UniplateNo for SpezUniplate<T>
+where
+    T: Eq + Clone + 'static,
+{
+    type T = T;
+    fn spez_try_uniplate(&self) -> (Tree<Self::T>, Box<dyn Fn(Tree<Self::T>) -> Self::T>) {
+        let self2 = self.0.clone();
+        (Tree::Zero, Box::new(move |_| self2.clone()))
+    }
+
+    #[inline(always)]
+    fn spez_impls_uniplate(&self) -> bool {
+        false
+    }
+}
+
+#[doc(inline)]
+/// Tries to call `Uniplate::uniplate` on `$x`, returning a default implementation if `$x` does not
+/// implement `Uniplate`.
+pub use super::try_uniplate;
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! try_uniplate {
+    ($x:expr) => {{
+        #[allow(unused_imports)]
+        use ::uniplate::spez::{SpezUniplate, UniplateNo, UniplateYes};
+        #[allow(clippy::needless_borrow)]
+        (&&SpezUniplate($x)).spez_try_biplate()
+    }};
+}
+#[doc(inline)]
+/// Returns whether `x` implements `Uniplate`.
+pub use super::impls_uniplate;
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impls_uniplate {
+    ($x:expr) => {{
+        #[allow(unused_imports)]
+        use ::uniplate::spez::{SpezUniplate, UniplateNo as _, UniplateYes as _};
+        #[allow(clippy::needless_borrow)]
+        (&&SpezUniplate($x)).spez_impls_uniplate()
+    }};
+}

--- a/uniplate/src/test_common/paper.rs
+++ b/uniplate/src/test_common/paper.rs
@@ -5,8 +5,7 @@ use crate::Uniplate;
 // Stmt and Expr to demonstrate and test multitype traversals.
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[biplate(to=Expr)]
-#[biplate(to=String,walk_into=[Expr])]
-#[uniplate(walk_into=[Expr])]
+#[biplate(to=String,)]
 pub enum Stmt {
     Assign(String, Expr),
     Sequence(Vec<Stmt>),
@@ -15,7 +14,6 @@ pub enum Stmt {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
-#[uniplate(walk_into=[Stmt])]
 #[biplate(to=String)]
 #[biplate(to=Stmt)]
 pub enum Expr {

--- a/uniplate/tests/derive-pass/conjure_ast.rs
+++ b/uniplate/tests/derive-pass/conjure_ast.rs
@@ -9,7 +9,7 @@ use uniplate::Uniplate;
 #[derive(Clone, Debug, PartialEq, Eq, Uniplate)]
 #[uniplate()]
 #[biplate(to=Constant)]
-#[biplate(to=String,walk_into=[Name])]
+#[biplate(to=String)]
 enum Expression {
     Nothing,
     Bubble(Metadata, Box<Expression>, Box<Expression>),

--- a/uniplate/tests/derive-pass/enums/biplate-stmt.rs
+++ b/uniplate/tests/derive-pass/enums/biplate-stmt.rs
@@ -1,14 +1,14 @@
 #![allow(dead_code)]
 
-use uniplate::{Uniplate, Biplate};
 use std::collections::VecDeque;
+use uniplate::{Biplate, Uniplate};
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[biplate(to=Expr)]
-#[biplate(to=i32,walk_into=[Expr,Option<Expr>])]
+#[biplate(to=i32)]
+#[biplate(to=String)]
 #[biplate(to=Option<Expr>)]
-#[biplate(to=String,walk_into=[Expr])]
-#[uniplate(walk_into=[Expr])]
+#[uniplate()]
 enum Stmt {
     Assign(String, Option<Expr>),
     Sequence(Vec<Stmt>),
@@ -17,7 +17,7 @@ enum Stmt {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
-#[uniplate(walk_into=[Stmt])]
+#[uniplate()]
 #[biplate(to=String)]
 #[biplate(to=Option<Expr>)]
 #[biplate(to=Stmt)]
@@ -36,7 +36,10 @@ pub fn main() {
     use Expr::*;
     use Stmt::*;
 
-    let stmt_1 = Assign("x".into(), Some(Div(Box::new(Val(2)), Box::new(Var("y".into())))));
+    let stmt_1 = Assign(
+        "x".into(),
+        Some(Div(Box::new(Val(2)), Box::new(Var("y".into())))),
+    );
 
     let strings_in_stmt_1: VecDeque<String> = stmt_1.universe_bi();
 
@@ -47,31 +50,33 @@ pub fn main() {
 
     // same type property
     let children: VecDeque<Stmt> = stmt_1.children_bi();
-    assert_eq!(children.len(),1);
-    assert_eq!(children[0],stmt_1);
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0], stmt_1);
 
     // test with_children_bi
     let children: VecDeque<String> = stmt_1.children_bi();
     let reconstructed: Stmt = stmt_1.with_children_bi(children);
-    assert_eq!(reconstructed,stmt_1);
+    assert_eq!(reconstructed, stmt_1);
 
     // test descend_bi on ints
-    let stmt_1_ints= VecDeque::from([2]);
+    let stmt_1_ints = VecDeque::from([2]);
 
-    assert_eq!(stmt_1.children_bi(),stmt_1_ints);
+    assert_eq!(stmt_1.children_bi(), stmt_1_ints);
 
-    let stmt_1_expected = Assign("x".into(), Some(Div(Box::new(Val(3)), Box::new(Var("y".into())))));
-    assert_eq!(stmt_1.with_children_bi(VecDeque::from([3])),stmt_1_expected);
+    let stmt_1_expected = Assign(
+        "x".into(),
+        Some(Div(Box::new(Val(3)), Box::new(Var("y".into())))),
+    );
+    assert_eq!(
+        stmt_1.with_children_bi(VecDeque::from([3])),
+        stmt_1_expected
+    );
 
-    let stmt_1_actual = stmt_1.descend_bi(&|x: i32| {
-        x+1
-    });
-    assert_eq!(stmt_1_expected,stmt_1_actual);
+    let stmt_1_actual = stmt_1.descend_bi(&|x: i32| x + 1);
+    assert_eq!(stmt_1_expected, stmt_1_actual);
 
-    // test transform_bi 
-    let stmt_1_actual = stmt_1.transform_bi(&|x: i32| {
-        x+1
-    });
+    // test transform_bi
+    let stmt_1_actual = stmt_1.transform_bi(&|x: i32| x + 1);
 
-    assert_eq!(stmt_1_expected,stmt_1_actual);
+    assert_eq!(stmt_1_expected, stmt_1_actual);
 }

--- a/uniplate/tests/derive-pass/enums/issue-16-biplate-to-vec-expr.rs
+++ b/uniplate/tests/derive-pass/enums/issue-16-biplate-to-vec-expr.rs
@@ -8,7 +8,7 @@ use uniplate::Biplate;
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[uniplate()]
-#[biplate(to=Vec<Stmt>,walk_into=[Expr])]
+#[biplate(to=Vec<Stmt>)]
 enum Stmt {
     Nothing,
     Assign(String, Expr),

--- a/uniplate/tests/derive-pass/generics/tree-uniplate-walk-into.rs
+++ b/uniplate/tests/derive-pass/generics/tree-uniplate-walk-into.rs
@@ -5,7 +5,7 @@
 //
 use uniplate::Uniplate;
 #[derive(Eq, PartialEq, Uniplate, Clone)]
-#[uniplate(walk_into=[T])]
+#[uniplate()]
 enum BinaryTree<T: PartialEq + Eq>
 where
     T: Ord,

--- a/uniplate/tests/derive-pass/structs/biplate-struct.rs
+++ b/uniplate/tests/derive-pass/structs/biplate-struct.rs
@@ -3,16 +3,16 @@ use uniplate::{Uniplate, Biplate};
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
 #[biplate(to=B)]
-#[biplate(to=i32,walk_into=[B])]
-#[uniplate(walk_into=[B])]
+#[biplate(to=i32,)]
+#[uniplate()]
 struct A {
     value: i32,
     children: Vec<B>,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Uniplate)]
-#[uniplate(walk_into=[A])]
-#[biplate(to=i32, walk_into=[A])]
+#[uniplate()]
+#[biplate(to=i32)]
 #[biplate(to=A)]
 struct B {
     value: i32,


### PR DESCRIPTION

Remove the `walk_into` attribute from the derive macro. When deriving a biplate
implementation, work out which types to walk into using auto-deref specialization.

For more info, see the commit log:

---

## Commit Log

- **feat: add specialization helpers for derive**
  Add specialisation helpers for the derive macro, that return a default
  implementation for `Biplate<To>` if the input does not implement
  `Biplate<To>`.
  
  The eventual aim of this change is to remove the `walk_into` attribute,
  and allow the derive macro to automatically infer which types we can
  walk into when deriving `Biplate<T>`. This commit just includes the
  specialization helpers needed to make this work: changing the derive
  macro will be done in a future commit.
  
  DETAILS
  
  The `try_biplate_to!` macro is the front-end of this specialisation
  code. `try_biplate_to!(x,T)` tries to call `Biplate<T>` on `x` -  if `x`
  implements `Biplate<T>`, it returns `x.biplate()`, otherwise it returns
  a default implementation of `Biplate<T>` that returns a `Tree::Zero`,
  denoting that the `x` contains no children of type `T`.
  
  This uses the auto-deref specialization trick
  (<https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html>)
  to provide two implementations of the `spez_try_biplate` method. To do
  this, I define the following traits, both containing `spez_try_biplate` as a
  method:
  
  1. `BiplateYes`, applicable when `Self: Biplate<T>`. Its
     implementation of `spez_try_biplate` calls `Biplate<T>::biplate` on
     the argument passed to it.
  
  2. `BiplateNo`, applicable always. Its implementation of
     `spez_try_biplate` returns the default implementation of
     `Biplate<T>`,
  
  `BiplateYes` has a higher priority than `BiplateNo`, making `BiplateNo`
  act like a fallback implementation when the type does not implement
  `Biplate<T>`.
  
  To make this trick work:
  
  * The traits are implemented on a wrapper type `SpezBiplate`, not
    the actual value types.
  * Both traits must be in scope.
  * The method must be called by doing `((&&SpezBiplate::(x,PhantomData::<T>)).spez_try_biplate()`.
  
  The `try_biplate_to!` macro encapsulates this boilerplate to make using
  this easier.
  
  In the upcoming derive macro changes, we will call `try_biplate_to!` on
  every field, and if that field does not implement `Biplate`,
  `try_biplate_to!` will give a default implementation. This removes the
  need to manually specify which types to walk into (i.e. call
  `Biplate<T>` recursively on) for each biplate instance.
  
  BACKGROUND
  
  `Biplate<T>` looks inside a value for all children of type `T`. The key
  feature of `Biplate` is that it can traverse through nested types when
  looking for a value. For example, if a value of type `Expresssion`
  contains a `Stmt` that contains a `String`, `Biplate<String> for
  Expression` should return that string.
  
  Currently, we require the user to explictly state which types to walk
  into for each `Biplate` instance. In the below example, we explicitly
  tell `Biplate` to look inside `Expr` for strings, so `Biplate<String>
  for Stmt` returns both the strings inside `Expr::Var` and
    `Stmt::Assign`.
  
  ```rs
  enum Stmt {
      Assign(String, Expr),
      Sequence(Vec<Stmt>),
      If(Expr, Box<Stmt>, Box<Stmt>),
      While(Expr, Box<Stmt>),
  }
  
  enum Expr {
      Add(Box<Expr>, Box<Expr>),
      Sub(Box<Expr>, Box<Expr>),
      Mul(Box<Expr>, Box<Expr>),
      Div(Box<Expr>, Box<Expr>),
      Val(i32),
      Var(String),
      Neg(Box<Expr>),
  }
  ```
  If we called `Biplate<String>` for all types inside `Expr`, instead of
  just those in the `walk_into` list, Rust would error, telling us that
  i32 does not implement `Biplate<String>`. Furthermore, as Rust does not
  support trait specialisation (multiple impl blocks applying to the same
  trait), specifying a default implementation of `Biplate<String>` is not
  possible.
  
  This commit gets around this language limitation by using the
  autoderef-specializaton trick
  (<https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html>),
  which gives us specialisation-like behaviour in stable Rust. This allows
  us to specify a default implementation for Biplate, and thus
  automatically infer which types to walk into when deriving biplate.
  

- **feat(derive)!: automatically determine types to walk into**
  Remove the `walk_into` attribute, and automatically determine the types
  to walk into using `try_biplate_to!`.
  
  This is a continuation of e5176a3 (feat: add specialization helpers for
  derive, 2025-07-24) - see that commit message for more details.
  
  BREAKING CHANGE: The `walk_into` field for the derive attributes
  `#[biplate]` and `#[uniplate]` has been removed. Types are now walked
  into if they implement the needed Uniplate or Biplate instance - i.e.
  `Biplate<T>` walk into fields of type `U` if `U` implements
  `Biplate<T>`.
  