### PR TITLE
fix: inspect tree children for zipper has_down

### DIFF
--- a/uniplate/src/tree.rs
+++ b/uniplate/src/tree.rs
@@ -24,6 +24,17 @@ pub enum Tree<T: Sized + Clone + Eq> {
 // worth it when we use all the children returned. This is what we use this for inside Uniplate.
 // Because of this, I think a .iter() / IntoIterator for Tree<&T> is a bad idea.
 
+impl<T: Sized + Clone + Eq> Tree<T> {
+    /// Returns true if the tree contains any `One` variants, false otherwise.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Tree::Zero => true,
+            Tree::One(_) => false,
+            Tree::Many(children) => children.iter().all(|tr| tr.is_empty()),
+        }
+    }
+}
+
 impl<T: Sized + Clone + Eq + 'static> IntoIterator for Tree<T> {
     type Item = T;
 

--- a/uniplate/src/zipper.rs
+++ b/uniplate/src/zipper.rs
@@ -139,10 +139,7 @@ impl<T: Uniplate> Zipper<T> {
     /// Check if the focus has children
     pub fn has_down(&self) -> bool {
         let (children, _) = self.focus.uniplate();
-        match children {
-            Tree::Zero => false,
-            _ => true,
-        }
+        !children.is_empty()
     }
 
     /// Sets the focus to the left sibling of the focus (if it exists).

--- a/uniplate/tests/zipper.rs
+++ b/uniplate/tests/zipper.rs
@@ -1,5 +1,4 @@
-use uniplate::zipper::Zipper;
-use uniplate_derive::Uniplate;
+use uniplate::{Uniplate, zipper::Zipper};
 
 #[derive(Clone, PartialEq, Eq, Debug, Uniplate)]
 enum Tree {
@@ -131,6 +130,15 @@ fn zipper_has_down() {
     zipper.go_down();
     assert!(zipper.has_down());
     zipper.go_down();
+    assert!(!zipper.has_down());
+}
+
+#[test]
+fn zipper_has_down_type_not_enterable() {
+    #[derive(Clone, PartialEq, Eq, Uniplate, Debug)]
+    struct Data(i32);
+
+    let zipper = Zipper::new(Data(0));
     assert!(!zipper.has_down());
 }
 


### PR DESCRIPTION
The following test case is failing:
```rust
#[derive(Clone, PartialEq, Eq, Uniplate)]
struct Data(i32);

let zipper = Zipper::new(Data(0));
assert!(!zipper.has_down());
```

In this case, `zipper.focus().uniplate().0` is `Many([Zero])`. Currently we are not checking for that:

https://github.com/conjure-cp/uniplate/blob/7724ce7e2783b17c091fac60c316281e15d13054/uniplate/src/zipper.rs#L140-L146

This PR adds a recursive `Tree::has_children` method which accounts for this case, and a regression test.