### PR TITLE
Remove CODEOWNERS entry for niklasdewally

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @niklasdewally
+


### PR DESCRIPTION
Enforcing reviews is now done with branch protection