### PR TITLE
feat: add try_replace_child_at for in-place nth-child updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Uniplate::try_replace_child_at` and `Biplate::try_replace_child_at_bi` /
+  `children_bi_count` for updating a single child by index. Derived `Uniplate`
+  implementations walk fields and `Vec`/`VecDeque` update same-type elements in
+  place without cloning siblings.
+
 ## [0.4.6](https://github.com/conjure-cp/uniplate/compare/v0.4.5...v0.4.6) - 2026-03-25
 
 This release consists of performance improvements.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/uniplate-derive/src/lib.rs
+++ b/uniplate-derive/src/lib.rs
@@ -35,6 +35,10 @@ fn derive_a_uniplate(state: &mut ParserState) -> TokenStream2 {
         ast::Data::DataEnum(x) => _derive_a_enum_uniplate(state, x),
         ast::Data::DataStruct(x) => _derive_a_struct_uniplate(state, x),
     };
+    let replace_tokens: TokenStream2 = match state.data.clone() {
+        ast::Data::DataEnum(x) => _derive_a_enum_try_replace_child_at(state, x),
+        ast::Data::DataStruct(x) => _derive_a_struct_try_replace_child_at(state, x),
+    };
 
     let mut generics = state.data.generics().clone();
     for (_, bounds) in generics.type_parameters.iter_mut() {
@@ -48,6 +52,10 @@ fn derive_a_uniplate(state: &mut ParserState) -> TokenStream2 {
         impl<#impl_bounds> ::uniplate::Uniplate for #from #where_clause {
             fn uniplate(&self) -> (::uniplate::Tree<#from>, Box<dyn Fn(::uniplate::Tree<#from>) -> #from>) {
                 #tokens
+            }
+
+            fn try_replace_child_at(&mut self, index: usize, child: #from) -> bool {
+                #replace_tokens
             }
         }
     }
@@ -115,6 +123,213 @@ fn _derive_a_enum_uniplate(state: &mut ParserState, data: ast::DataEnum) -> Toke
     quote! {
         match self {
             #(#variant_tokens)*
+        }
+    }
+}
+
+fn _derive_a_enum_try_replace_child_at(
+    state: &mut ParserState,
+    data: ast::DataEnum,
+) -> TokenStream2 {
+    let enum_ident = state.data.ident();
+    let mut variant_tokens = VecDeque::<TokenStream2>::new();
+
+    for variant in data.variants {
+        let ident = variant.ident.clone();
+        let field_idents: Vec<_> = variant.fields.idents().collect();
+        let field_replace = _derive_fields_try_replace_child_at(state, &variant.fields, true);
+
+        match &variant.fields {
+            // Match on `&mut self`: Rust 2024 match ergonomics bind fields as `&mut _`
+            // without writing `ref mut` explicitly.
+            ast::Fields::Struct(_) => {
+                variant_tokens.push_back(quote! {
+                    #enum_ident::#ident { #(#field_idents),* } => {
+                        #field_replace
+                    },
+                });
+            }
+            ast::Fields::Tuple(_) => {
+                variant_tokens.push_back(quote! {
+                    #enum_ident::#ident(#(#field_idents),*) => {
+                        #field_replace
+                    },
+                });
+            }
+            ast::Fields::Unit => {
+                variant_tokens.push_back(quote! {
+                    #enum_ident::#ident => {
+                        let _ = &child;
+                        false
+                    },
+                });
+            }
+        }
+    }
+
+    let variant_tokens = variant_tokens.iter();
+    quote! {
+        let mut index = index;
+        let mut child = ::std::option::Option::Some(child);
+        match self {
+            #(#variant_tokens)*
+        }
+    }
+}
+
+fn _derive_a_struct_try_replace_child_at(
+    state: &mut ParserState,
+    data: ast::DataStruct,
+) -> TokenStream2 {
+    if data.fields.is_empty() {
+        return quote! { false };
+    }
+
+    let field_replace = _derive_fields_try_replace_child_at(state, &data.fields, false);
+    quote! {
+        let mut index = index;
+        let mut child = ::std::option::Option::Some(child);
+        #field_replace
+    }
+}
+
+/// Generates field-by-field try-replace.
+///
+/// When `bindings` is true, fields are `ref mut` match bindings; otherwise they are `self.field`.
+fn _derive_fields_try_replace_child_at(
+    state: &mut ParserState,
+    fields: &ast::Fields,
+    bindings: bool,
+) -> TokenStream2 {
+    let from = state.from.to_token_stream();
+    let mut parts = Vec::<TokenStream2>::new();
+
+    for (member, typ) in fields.defs() {
+        let field_path = if bindings {
+            match member {
+                syn::Member::Named(ident) => quote!(#ident),
+                syn::Member::Unnamed(index) => {
+                    let ident = format_ident!("_{}", index);
+                    quote!(#ident)
+                }
+            }
+        } else {
+            quote!(self.#member)
+        };
+
+        parts.push(_derive_one_field_try_replace(
+            &from, typ, field_path, bindings,
+        ));
+    }
+
+    quote! {
+        #(#parts)*
+        let _ = child;
+        false
+    }
+}
+
+fn _derive_one_field_try_replace(
+    from: &TokenStream2,
+    typ: &ast::Type,
+    field_path: TokenStream2,
+    bindings: bool,
+) -> TokenStream2 {
+    let mut_ref = if bindings {
+        quote!(#field_path)
+    } else {
+        quote!(&mut #field_path)
+    };
+
+    match typ {
+        ast::Type::Basic(_) => {
+            quote! {
+                {
+                    let count = ::uniplate::try_biplate_children_bi_count!(#mut_ref, #from);
+                    if index < count {
+                        return ::uniplate::try_biplate_replace_child_at!(
+                            #mut_ref,
+                            #from,
+                            index,
+                            child.take().expect("replacement child already taken")
+                        );
+                    }
+                    index -= count;
+                }
+            }
+        }
+        ast::Type::BoxedBasic(_) => {
+            let inner = if bindings {
+                quote!(&mut **#field_path)
+            } else {
+                quote!(&mut *#field_path)
+            };
+            quote! {
+                {
+                    let count = ::uniplate::try_biplate_children_bi_count!(#inner, #from);
+                    if index < count {
+                        return ::uniplate::try_biplate_replace_child_at!(
+                            #inner,
+                            #from,
+                            index,
+                            child.take().expect("replacement child already taken")
+                        );
+                    }
+                    index -= count;
+                }
+            }
+        }
+        ast::Type::Tuple(tuple_type) => {
+            let n = tuple_type.n;
+            let idxs: Vec<_> = (0..n).map(syn::Index::from).collect();
+            let mut tuple_parts = Vec::new();
+            for idx in &idxs {
+                let elem = quote!(&mut (#field_path).#idx);
+                tuple_parts.push(quote! {
+                    {
+                        let count = ::uniplate::try_biplate_children_bi_count!(#elem, #from);
+                        if index < count {
+                            return ::uniplate::try_biplate_replace_child_at!(
+                                #elem,
+                                #from,
+                                index,
+                                child.take().expect("replacement child already taken")
+                            );
+                        }
+                        index -= count;
+                    }
+                });
+            }
+            let _ = n;
+            quote! { #(#tuple_parts)* }
+        }
+        ast::Type::BoxedTuple(tuple_type) => {
+            let n = tuple_type.n;
+            let idxs: Vec<_> = (0..n).map(syn::Index::from).collect();
+            let mut tuple_parts = Vec::new();
+            for idx in &idxs {
+                let elem = if bindings {
+                    quote!(&mut (**#field_path).#idx)
+                } else {
+                    quote!(&mut (*#field_path).#idx)
+                };
+                tuple_parts.push(quote! {
+                    {
+                        let count = ::uniplate::try_biplate_children_bi_count!(#elem, #from);
+                        if index < count {
+                            return ::uniplate::try_biplate_replace_child_at!(
+                                #elem,
+                                #from,
+                                index,
+                                child.take().expect("replacement child already taken")
+                            );
+                        }
+                        index -= count;
+                    }
+                });
+            }
+            let _ = n;
+            quote! { #(#tuple_parts)* }
         }
     }
 }
@@ -538,6 +753,18 @@ fn _derive_identity_biplate(state: &mut ParserState, from: TokenStream2) -> Toke
                     let ::uniplate::Tree::One(x) = x else {todo!()};
                     x
                 }))
+            }
+
+            fn children_bi_count(&self) -> usize {
+                1
+            }
+
+            fn try_replace_child_at_bi(&mut self, index: usize, child: #from) -> bool {
+                if index != 0 {
+                    return false;
+                }
+                *self = child;
+                true
             }
         }
     }

--- a/uniplate/src/lib.rs
+++ b/uniplate/src/lib.rs
@@ -138,6 +138,58 @@ macro_rules! derive_iter {
             T: Clone + Eq + ::uniplate::Uniplate + Sized + 'static,
             F: Clone + Eq + ::uniplate::Uniplate + ::uniplate::Biplate<T> + Sized + 'static,
         {
+            fn children_bi_count(&self) -> usize {
+                if std::any::TypeId::of::<T>() == std::any::TypeId::of::<F>() {
+                    self.len()
+                } else if std::any::TypeId::of::<T>() == std::any::TypeId::of::<$iter_ty<F>>() {
+                    1
+                } else {
+                    self.iter()
+                        .map(|item| <F as ::uniplate::Biplate<T>>::children_bi_count(item))
+                        .sum()
+                }
+            }
+
+            fn try_replace_child_at_bi(&mut self, index: usize, child: T) -> bool {
+                // T == F: children are exactly the collection elements.
+                if std::any::TypeId::of::<T>() == std::any::TypeId::of::<F>() {
+                    if index >= self.len() {
+                        return false;
+                    }
+                    // SAFETY: TypeId equality means T and F are the same type.
+                    unsafe {
+                        let child_as_f = std::mem::transmute_copy::<T, F>(&child);
+                        std::mem::forget(child);
+                        // Vec and VecDeque both support IndexMut.
+                        self[index] = child_as_f;
+                    }
+                    return true;
+                }
+
+                // Biplate<Vec<F>> for Vec<F>: the collection is its only child.
+                if std::any::TypeId::of::<T>() == std::any::TypeId::of::<$iter_ty<F>>() {
+                    if index != 0 {
+                        return false;
+                    }
+                    // SAFETY: TypeId equality means T and $iter_ty<F> are the same type.
+                    unsafe {
+                        let child_as_self = std::mem::transmute_copy::<T, $iter_ty<F>>(&child);
+                        std::mem::forget(child);
+                        *self = child_as_self;
+                    }
+                    return true;
+                }
+
+                // Nested T's inside each F: fall back to the default clone/rebuild path.
+                let mut children = self.children_bi();
+                if index >= children.len() {
+                    return false;
+                }
+                children[index] = child;
+                *self = self.with_children_bi(children);
+                true
+            }
+
             fn biplate(
                 &self,
             ) -> (

--- a/uniplate/src/spez.rs
+++ b/uniplate/src/spez.rs
@@ -18,5 +18,29 @@ use std::marker::PhantomData;
 /// Biplate calls in the derive macro.
 pub struct SpezBiplate<Src, Dest>(pub Src, pub PhantomData<Dest>);
 
+/// Mutable specialisation wrapper for [`Biplate::try_replace_child_at_bi`] / `children_bi_count`.
+///
+/// Stores a raw pointer so autoref specialisation can still run through shared references while
+/// mutating the source. Only construct this from a live `&mut Src` and do not use it after that
+/// borrow ends.
+pub struct SpezBiplateMut<Src, Dest> {
+    /// Raw pointer to the value being specialised over. See [`SpezBiplateMut::new`].
+    pub src: *mut Src,
+    _pd: PhantomData<Dest>,
+}
+
+impl<Src, Dest> SpezBiplateMut<Src, Dest> {
+    /// Creates a mutable specialisation wrapper from `src`.
+    ///
+    /// The returned wrapper must only be used while `src` is still exclusively borrowed.
+    #[inline]
+    pub fn new(src: &mut Src) -> Self {
+        Self {
+            src: src as *mut Src,
+            _pd: PhantomData,
+        }
+    }
+}
+
 /// A wrapper type used for auto-deref specialisation of `Uniplate`.
 pub struct SpezUniplate<Src>(pub Src);

--- a/uniplate/src/spez/biplate.rs
+++ b/uniplate/src/spez/biplate.rs
@@ -15,6 +15,12 @@ pub trait BiplateYes {
 
     #[allow(missing_docs)]
     fn spez_impls_biplate(&self) -> bool;
+
+    #[allow(missing_docs)]
+    fn spez_children_bi_count(&self) -> usize;
+
+    #[allow(missing_docs)]
+    fn spez_try_replace_child_at_bi(&self, index: usize, child: Self::Dest) -> bool;
 }
 
 /// Specialization proxy for [`uniplate::Biplate`].
@@ -29,6 +35,12 @@ pub trait BiplateNo {
 
     #[allow(missing_docs)]
     fn spez_impls_biplate(&self) -> bool;
+
+    #[allow(missing_docs)]
+    fn spez_children_bi_count(&self) -> usize;
+
+    #[allow(missing_docs)]
+    fn spez_try_replace_child_at_bi(&self, index: usize, child: Self::Dest) -> bool;
 }
 
 // Implementation of specialisation.
@@ -48,6 +60,45 @@ where
     #[inline(always)]
     fn spez_impls_biplate(&self) -> bool {
         true
+    }
+
+    fn spez_children_bi_count(&self) -> usize {
+        self.0.children_bi_count()
+    }
+
+    fn spez_try_replace_child_at_bi(&self, index: usize, child: Self::Dest) -> bool {
+        // Owned wrapper: mutation is not supported through `SpezBiplate`.
+        let _ = (index, child);
+        false
+    }
+}
+
+impl<Src, Dest> BiplateYes for &SpezBiplateMut<Src, Dest>
+where
+    Src: Biplate<Dest>,
+    Dest: Eq + Clone + Uniplate,
+{
+    type Src = Src;
+    type Dest = Dest;
+
+    fn spez_try_biplate(&self) -> (Tree<Self::Dest>, Box<dyn Fn(Tree<Self::Dest>) -> Self::Src>) {
+        // SAFETY: SpezBiplateMut is only constructed from a live &mut Src.
+        unsafe { (*self.src).biplate() }
+    }
+
+    #[inline(always)]
+    fn spez_impls_biplate(&self) -> bool {
+        true
+    }
+
+    fn spez_children_bi_count(&self) -> usize {
+        // SAFETY: SpezBiplateMut is only constructed from a live &mut Src.
+        unsafe { (*self.src).children_bi_count() }
+    }
+
+    fn spez_try_replace_child_at_bi(&self, index: usize, child: Self::Dest) -> bool {
+        // SAFETY: SpezBiplateMut is only constructed from a live &mut Src.
+        unsafe { (*self.src).try_replace_child_at_bi(index, child) }
     }
 }
 
@@ -85,6 +136,78 @@ where
     #[inline(always)]
     fn spez_impls_biplate(&self) -> bool {
         false
+    }
+
+    fn spez_children_bi_count(&self) -> usize {
+        if TypeId::of::<Src>() == TypeId::of::<Dest>() {
+            1
+        } else {
+            0
+        }
+    }
+
+    fn spez_try_replace_child_at_bi(&self, index: usize, child: Self::Dest) -> bool {
+        let _ = (index, child);
+        false
+    }
+}
+
+impl<Src, Dest> BiplateNo for SpezBiplateMut<Src, Dest>
+where
+    Src: Eq + Clone + 'static,
+    Dest: Eq + Clone + Uniplate + 'static,
+{
+    type Src = Src;
+    type Dest = Dest;
+
+    fn spez_try_biplate(&self) -> (Tree<Self::Dest>, Box<dyn Fn(Tree<Self::Dest>) -> Self::Src>) {
+        // SAFETY: SpezBiplateMut is only constructed from a live &mut Src.
+        let this = unsafe { (*self.src).clone() };
+        if TypeId::of::<Src>() == TypeId::of::<Dest>() {
+            unsafe {
+                let this_as_dest: Dest = std::mem::transmute::<&Src, &Dest>(&this).clone();
+                let tree = Tree::One(this_as_dest);
+                let ctx = Box::new(move |x| {
+                    let Tree::One(x) = x else {
+                        panic!();
+                    };
+                    std::mem::transmute::<&Dest, &Src>(&x).clone()
+                });
+                (tree, ctx)
+            }
+        } else {
+            (Tree::Zero, Box::new(move |_| this.clone()))
+        }
+    }
+
+    #[inline(always)]
+    fn spez_impls_biplate(&self) -> bool {
+        false
+    }
+
+    fn spez_children_bi_count(&self) -> usize {
+        if TypeId::of::<Src>() == TypeId::of::<Dest>() {
+            1
+        } else {
+            0
+        }
+    }
+
+    fn spez_try_replace_child_at_bi(&self, index: usize, child: Self::Dest) -> bool {
+        if TypeId::of::<Src>() == TypeId::of::<Dest>() {
+            if index != 0 {
+                return false;
+            }
+            // SAFETY: TypeId equality + SpezBiplateMut pointer invariant.
+            unsafe {
+                let child_as_src = std::mem::transmute_copy::<Dest, Src>(&child);
+                std::mem::forget(child);
+                *self.src = child_as_src;
+            }
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -125,7 +248,7 @@ use crate::Uniplate;
 /// ```
 pub use crate::impls_biplate_to;
 
-use super::SpezBiplate;
+use super::{SpezBiplate, SpezBiplateMut};
 
 #[macro_export]
 #[doc(hidden)]
@@ -135,5 +258,29 @@ macro_rules! impls_biplate_to {
         use ::uniplate::spez::{BiplateNo as _, BiplateYes as _, SpezBiplate};
         #[allow(clippy::needless_borrow)]
         (&&SpezBiplate($x, std::marker::PhantomData::<$t>)).spez_impls_biplate()
+    }};
+}
+
+/// Spez-aware [`Biplate::children_bi_count`].
+#[macro_export]
+#[doc(hidden)]
+macro_rules! try_biplate_children_bi_count {
+    ($x:expr, $t:ty) => {{
+        #[allow(unused_imports)]
+        use ::uniplate::spez::{BiplateNo, BiplateYes, SpezBiplateMut};
+        let spez = ::uniplate::spez::SpezBiplateMut::<_, $t>::new($x);
+        (&&spez).spez_children_bi_count()
+    }};
+}
+
+/// Spez-aware [`Biplate::try_replace_child_at_bi`].
+#[macro_export]
+#[doc(hidden)]
+macro_rules! try_biplate_replace_child_at {
+    ($x:expr, $t:ty, $index:expr, $child:expr) => {{
+        #[allow(unused_imports)]
+        use ::uniplate::spez::{BiplateNo, BiplateYes, SpezBiplateMut};
+        let spez = ::uniplate::spez::SpezBiplateMut::<_, $t>::new($x);
+        (&&spez).spez_try_replace_child_at_bi($index, $child)
     }};
 }

--- a/uniplate/src/traits/biplate.rs
+++ b/uniplate/src/traits/biplate.rs
@@ -85,6 +85,45 @@ where
         self.biplate().0.list().0
     }
 
+    /// Number of children that would be returned by [`children_bi`](Self::children_bi).
+    ///
+    /// The default implementation builds the child list. Collection types override this when the
+    /// count is available without cloning siblings.
+    fn children_bi_count(&self) -> usize {
+        self.children_bi().len()
+    }
+
+    /// Replaces the `index`th child of type `To` within `self`.
+    ///
+    /// Returns `false` when `index` is out of range.
+    ///
+    /// The default implementation uses [`children_bi`](Self::children_bi) and
+    /// [`with_children_bi`](Self::with_children_bi). Types with owned same-type children (e.g.
+    /// `Vec<T>: Biplate<T>`) override this for an in-place update.
+    fn try_replace_child_at_bi(&mut self, index: usize, child: To) -> bool {
+        if std::any::TypeId::of::<Self>() == std::any::TypeId::of::<To>() {
+            if index != 0 {
+                return false;
+            }
+            // Biplate<T> for T treats the value as its only child.
+            // SAFETY: TypeId equality means Self and To are the same type.
+            unsafe {
+                let child_as_self = std::mem::transmute_copy::<To, Self>(&child);
+                std::mem::forget(child);
+                *self = child_as_self;
+            }
+            return true;
+        }
+
+        let mut children = self.children_bi();
+        if index >= children.len() {
+            return false;
+        }
+        children[index] = child;
+        *self = self.with_children_bi(children);
+        true
+    }
+
     /// Applies the given function to all nodes bottom up.
     ///
     /// Biplate variant of [`Uniplate::transform`]

--- a/uniplate/src/traits/uniplate.rs
+++ b/uniplate/src/traits/uniplate.rs
@@ -63,6 +63,24 @@ where
         }
     }
 
+    /// Replaces the `index`th direct child of `self`.
+    ///
+    /// Returns `false` when `index` is out of range.
+    ///
+    /// The default implementation uses [`children`](Self::children) and
+    /// [`with_children`](Self::with_children), which clones every sibling. Derived `Uniplate`
+    /// implementations override this to update a single child slot when possible (in particular
+    /// for owned `Vec` children).
+    fn try_replace_child_at(&mut self, index: usize, child: Self) -> bool {
+        let mut children = self.children();
+        if index >= children.len() {
+            return false;
+        }
+        children[index] = child;
+        *self = self.with_children(children);
+        true
+    }
+
     /// Applies the given function to all nodes bottom up.
     fn transform(&self, f: &impl Fn(Self) -> Self) -> Self {
         let (children, ctx) = self.uniplate();

--- a/uniplate/tests/try_replace_child_at.rs
+++ b/uniplate/tests/try_replace_child_at.rs
@@ -1,0 +1,38 @@
+use uniplate::Uniplate;
+
+#[derive(Clone, Debug, PartialEq, Eq, Uniplate)]
+#[uniplate()]
+enum Expr {
+    Val(i32),
+    Neg(Box<Expr>),
+    Add(Box<Expr>, Box<Expr>),
+    Sum(Vec<Expr>),
+}
+
+#[test]
+fn replaces_boxed_child_in_place() {
+    let mut expr = Expr::Neg(Box::new(Expr::Val(1)));
+    assert!(expr.try_replace_child_at(0, Expr::Val(9)));
+    assert_eq!(expr, Expr::Neg(Box::new(Expr::Val(9))));
+    assert!(!expr.try_replace_child_at(1, Expr::Val(0)));
+}
+
+#[test]
+fn replaces_vec_child_without_changing_siblings() {
+    let mut expr = Expr::Sum(vec![Expr::Val(0), Expr::Val(1), Expr::Val(2)]);
+    assert!(expr.try_replace_child_at(1, Expr::Val(99)));
+    assert_eq!(
+        expr,
+        Expr::Sum(vec![Expr::Val(0), Expr::Val(99), Expr::Val(2)])
+    );
+}
+
+#[test]
+fn replaces_binary_child() {
+    let mut expr = Expr::Add(Box::new(Expr::Val(1)), Box::new(Expr::Val(2)));
+    assert!(expr.try_replace_child_at(1, Expr::Val(7)));
+    assert_eq!(
+        expr,
+        Expr::Add(Box::new(Expr::Val(1)), Box::new(Expr::Val(7)))
+    );
+}


### PR DESCRIPTION
Derived Uniplate walks fields via spez-aware Biplate helpers, and Vec/VecDeque replace same-type elements without cloning siblings. This unblocks Oxide arena ancestor sync on wide matrices/roots.