### PR TITLE
chore: bump rand to 0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,9 +517,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
dependabot is keen that we update rand to at least 0.9.4, but cannot create a PR automatically. 